### PR TITLE
Change HUcast and RAcast shorthand to the more common standard

### DIFF
--- a/src/StaticGameData.cc
+++ b/src/StaticGameData.cc
@@ -332,9 +332,9 @@ const char* abbreviation_for_char_class(uint8_t cls) {
   static const array<const char*, 12> names = {
       "HUmr",
       "HUnl",
-      "HUcs",
+      "HUct",
       "RAmr",
-      "RAcs",
+      "RAct",
       "RAcl",
       "FOml",
       "FOnm",


### PR DESCRIPTION
Never seen HUcs and RAcs in common usage, plus they are somewhat ambiguous, so changed to HUct and RAct which are less ambigious!