### PR TITLE
Adjust PSOPC Patch System Directory Structure

### DIFF
--- a/system/patch-pc/Media/PSO/newserv-test-pc.txt
+++ b/system/patch-pc/Media/PSO/newserv-test-pc.txt
@@ -1,0 +1,1 @@
+This file exists to test the patch download system.

--- a/system/patch-pc/data/newserv-test-pc.txt
+++ b/system/patch-pc/data/newserv-test-pc.txt
@@ -1,1 +1,0 @@
-This file exists to test the patch download system.


### PR DESCRIPTION
Good afternoon,

To make things easier on users setting the server up for PSOPC clients, consider this PR that adjusts the directory structure. 

Unline _Blue Burst_ which stores many files within [installpath]/data, PSO PC's patch files are typically located in [installpath]/Media/PSO. This is where several of the game's non-executable files are located, including quests, textures, etc.

This layout just makes it a little clearer where to add any patches that a server owner would want their PSO PC clients to download.

For what it's worth, it looks like this doesn't affect any smoke tests. I believe any existing ones would be unaffected since the server does not include the directory in the output, and current smoke tests look like they bypass the patch server. I may have missed a reference, so let me know if there's anything else that needs to be done here.