### PR TITLE
Adjust loading maps for GC NTE

### DIFF
--- a/src/Map.cc
+++ b/src/Map.cc
@@ -1734,6 +1734,47 @@ static const vector<AreaMapFileInfo> map_file_info_dc_nte = {
     {nullptr, {}, {}},
 };
 
+static const vector<vector<AreaMapFileInfo>> map_file_info_gc_nte = {
+    {
+        // Episode 1 Non-solo
+        {"city00", {}, {0}},
+        {"forest01", {}, {0, 1, 2, 3, 4}},
+        {"forest02", {}, {0, 1, 2, 3, 4}},
+        {"cave01", {0, 1, 2}, {0, 1}},
+        {"cave02", {0, 1, 2}, {0, 1}},
+        {"cave03", {0, 1, 2}, {0, 1}},
+        {"machine01", {0, 1, 2}, {0, 1}},
+        {"machine02", {0, 1, 2}, {0, 1}},
+        {"ancient01", {0, 1, 2}, {0, 1}},
+        {"ancient02", {0, 1, 2}, {0, 1}},
+        {"ancient03", {0, 1, 2}, {0, 1}},
+        {"boss01", {}, {}},
+        {"boss02", {}, {}},
+        {"boss03", {}, {}},
+        {"boss04", {}, {}},
+        {nullptr, {}, {}},
+    },
+    {
+        // Episode 2 Non-solo
+        {"labo00", {}, {0}},
+        {"ruins01", {0, 1}, {0}},
+        {"ruins02", {0, 1}, {0}},
+        {"space01", {0, 1}, {0}},
+        {"space02", {0, 1}, {0}},
+        {"jungle01", {}, {0, 1}},
+        {"jungle02", {}, {0, 1}},
+        {"jungle03", {}, {0, 1}},
+        {"jungle04", {0, 1}, {0}},
+        {"jungle05", {}, {0, 1}},
+        {nullptr, {}, {}},
+        {nullptr, {}, {}},
+        {"boss05", {}, {}},
+        {"boss06", {}, {}},
+        {"boss07", {}, {}},
+        {"boss08", {}, {}},
+    },
+};
+
 // These are indexed as [episode][is_solo][floor], where episode is 0-2
 static const vector<vector<vector<AreaMapFileInfo>>> map_file_info = {
     {
@@ -1867,7 +1908,19 @@ const AreaMapFileInfo& file_info_for_variation(
   const vector<AreaMapFileInfo>* solo_index = nullptr;
   if (version == Version::DC_NTE) {
     multi_index = &map_file_info_dc_nte;
-  } else {
+  } else if (version == Version::GC_NTE) {
+    switch (episode) {
+      case Episode::EP1:
+        multi_index = &map_file_info_gc_nte.at(0);
+        break;
+      case Episode::EP2:
+        multi_index = &map_file_info_gc_nte.at(1);
+        break;
+      default:
+        throw invalid_argument("episode has no maps");
+    }
+  }
+   else {
     switch (episode) {
       case Episode::EP1:
         multi_index = &map_file_info.at(0).at(0);


### PR DESCRIPTION
This pull request adjusts how we load maps for the GameCube Trial Edition.

**Overview**
The maps themselves are very odd (even aside from 'labo' actually being Pioneer 2). For instance, seabed01 and seabed02 will error out about them not being a multiple of the other. I'm not sure there's actual data in these, I assume they may be blanked out. (If this is something else, please feel free to correct me.) 

There are also very likely GameJam remnants littered into the client maps. I don't think these are used by the client unless modified to do so. (search gj and jm in the NTE maps directory. haven't checked, but I'd bet boss05 is actually just a re-used boss02...)

**The Problem**
With the latest commit, when a user tries to create an Episode II room, they'll be disconnected due to an error. Depending on what's adjusted, it'll complain about certain maps missing and/or the seabed issue noted above. (Oddly enough, it is happy with Olga Flow so we'll keep that in?)

**The Solution?**
To try to solve this, I've adjusted -- to the best of my ability -- the loading function for the GC NTE specifically and tried to use your styling as possible.

I believe this should align with the map files, **but please check my work.** The one I am most unsure of is `jungle04`.

**Side Note**
Here's the output when you add in the entries for `seabed01` and `seabed02`:

```
I 22095 2024-01-17 18:43:51 - [Game:15] Created
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_labo00_00e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_labo00_00o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_ruins01_00_00e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_ruins01_00_00o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_ruins02_00_00e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_ruins02_00_00o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_space01_01_00e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_space01_01_00o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_space02_00_00e.dat from default maps
W 22095 2024-01-17 18:43:51 - [Lobby:00000015:map] (Entry 102, offset 1CB0 in file) Invalid enemy type 0000
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_space02_00_00o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle01_00e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle01_00o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle02_01e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle02_01o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle03_01e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle03_01o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle04_01_00e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle04_01_00o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle05_00e.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_jungle05_00o.dat from default maps
I 22095 2024-01-17 18:43:51 - [StaticGameData] Loaded map_seabed01_00_00e.dat from default maps
W 22095 2024-01-17 18:43:51 - [Server] Error processing client command: data size is not a multiple of entry size
I 22095 2024-01-17 18:43:51 - [Server] Client disconnected: C-2 on fd 39
I 22095 2024-01-17 18:43:51 - [C-2] Deleted
```

Additionally, attached is the logfile from an instance with this PR based on the latest commit that can successfully make a GC NTE game. [PR_Log.txt](https://github.com/fuzziqersoftware/newserv/files/13971106/PR_Log.txt)