### PR TITLE
Make Choice Search show full Section ID

### DIFF
--- a/src/ReceiveCommands.cc
+++ b/src/ReceiveCommands.cc
@@ -3862,7 +3862,7 @@ static void on_choice_search_t(shared_ptr<Client> c, const ChoiceSearchConfig& c
         string info_string = string_printf("%s Lv%zu\n%s\n",
             name_for_char_class(lp->disp.visual.char_class),
             static_cast<size_t>(lp->disp.stats.level + 1),
-            abbreviation_for_section_id(lp->disp.visual.section_id));
+            name_for_section_id(lp->disp.visual.section_id));
         result.info_string.encode(info_string, c->language());
         string location_string;
         if (l->is_game()) {


### PR DESCRIPTION
I didn't actually test this I just assume this will work. Doing it since there's an extra line break in Choice Search now so the abbreviation is unnecessary.