### PR TITLE
Fix typo in GC targets for XB

### DIFF
--- a/system/client-functions/ReticleColors/GCReticleColors.4OED.patch.s
+++ b/system/client-functions/ReticleColors/GCReticleColors.4OED.patch.s
@@ -1,4 +1,4 @@
-.meta name="DC targets"
+.meta name="GC targets"
 .meta description="Change the target\nreticle colors to\nthose used on the\nGameCube"
 # Original code by Ralf @ GC-Forever and Aleron Ives
 # https://www.gc-forever.com/forums/viewtopic.php?t=2050

--- a/system/client-functions/ReticleColors/GCReticleColors.4OEU.patch.s
+++ b/system/client-functions/ReticleColors/GCReticleColors.4OEU.patch.s
@@ -1,4 +1,4 @@
-.meta name="DC targets"
+.meta name="GC targets"
 .meta description="Change the target\nreticle colors to\nthose used on the\nGameCube"
 # Original code by Ralf @ GC-Forever and Aleron Ives
 # https://www.gc-forever.com/forums/viewtopic.php?t=2050

--- a/system/client-functions/ReticleColors/GCReticleColors.4OJB.patch.s
+++ b/system/client-functions/ReticleColors/GCReticleColors.4OJB.patch.s
@@ -1,4 +1,4 @@
-.meta name="DC targets"
+.meta name="GC targets"
 .meta description="Change the target\nreticle colors to\nthose used on the\nGameCube"
 # Original code by Ralf @ GC-Forever and Aleron Ives
 # https://www.gc-forever.com/forums/viewtopic.php?t=2050

--- a/system/client-functions/ReticleColors/GCReticleColors.4OJD.patch.s
+++ b/system/client-functions/ReticleColors/GCReticleColors.4OJD.patch.s
@@ -1,4 +1,4 @@
-.meta name="DC targets"
+.meta name="GC targets"
 .meta description="Change the target\nreticle colors to\nthose used on the\nGameCube"
 # Original code by Ralf @ GC-Forever and Aleron Ives
 # https://www.gc-forever.com/forums/viewtopic.php?t=2050

--- a/system/client-functions/ReticleColors/GCReticleColors.4OJU.patch.s
+++ b/system/client-functions/ReticleColors/GCReticleColors.4OJU.patch.s
@@ -1,4 +1,4 @@
-.meta name="DC targets"
+.meta name="GC targets"
 .meta description="Change the target\nreticle colors to\nthose used on the\nGameCube"
 # Original code by Ralf @ GC-Forever and Aleron Ives
 # https://www.gc-forever.com/forums/viewtopic.php?t=2050

--- a/system/client-functions/ReticleColors/GCReticleColors.4OPD.patch.s
+++ b/system/client-functions/ReticleColors/GCReticleColors.4OPD.patch.s
@@ -1,4 +1,4 @@
-.meta name="DC targets"
+.meta name="GC targets"
 .meta description="Change the target\nreticle colors to\nthose used on the\nGameCube"
 # Original code by Ralf @ GC-Forever and Aleron Ives
 # https://www.gc-forever.com/forums/viewtopic.php?t=2050

--- a/system/client-functions/ReticleColors/GCReticleColors.4OPU.patch.s
+++ b/system/client-functions/ReticleColors/GCReticleColors.4OPU.patch.s
@@ -1,4 +1,4 @@
-.meta name="DC targets"
+.meta name="GC targets"
 .meta description="Change the target\nreticle colors to\nthose used on the\nGameCube"
 # Original code by Ralf @ GC-Forever and Aleron Ives
 # https://www.gc-forever.com/forums/viewtopic.php?t=2050


### PR DESCRIPTION
As title; it displays as "DC targets" in game.