### PR TITLE
Add Ultimate Map Fix patches for DCv2

### DIFF
--- a/system/client-functions/UltimateMapFix/UltimateMapFix.2OEF.patch.s
+++ b/system/client-functions/UltimateMapFix/UltimateMapFix.2OEF.patch.s
@@ -1,0 +1,66 @@
+.meta name="Ultimate map fix"
+.meta description="Add missing maps\nto Ultimate for\ncertain quests"
+
+entry_ptr:
+reloc0:
+  .offsetof start
+start:
+  .include  WriteCodeBlocksDC
+
+# Modify location of Ultimate Cave 1 map pointer table to 8C008100 and make it have 6 entries
+  .align    4
+  .data     0x8C32FED0
+  .data     6
+  .binary   0081008C0600
+
+# Modify location of Ultimate Cave 3 map pointer table to 8C008130 and make it have 6 entries
+  .align    4
+  .data     0x8C32FEE0
+  .data     6
+  .binary   3081008C0600
+
+# Modify location of Ultimate Mine 1 map pointer table to 8C008160 and make it have 6 entries
+  .align    4
+  .data     0x8C32FEE8
+  .data     6
+  .binary   6081008C0600
+
+# Modify location of Ultimate Mine 2 map pointer table to 8C008190 and make it have 6 entries
+  .align    4
+  .data     0x8C32FEF0
+  .data     6
+  .binary   9081008C0600
+
+# New map pointer table for Cave 1
+  .align    4
+  .data     0x8C008100
+  .data     48
+  .binary   5704338C6304338C5704338C7204338C5704338C8104338C5704338C9004338C5704338C9F04338C5704338C0082008C
+
+# New map pointer table for Cave 3
+  .align    4
+  .data     0x8C008130
+  .data     48
+  .binary   0505338C1105338C0505338C4D05338C0505338C2F05338C0505338C3E05338C0505338C4D05338C0505338C0F82008C
+
+# New map pointer table for Mine 1
+  .align    4
+  .data     0x8C008160
+  .data     48
+  .binary   5C05338C6B05338C5C05338C7D05338C5C05338C8F05338C5C05338CA105338C5C05338CB305338C5C05338C1E82008C
+
+# New map pointer table for Mine 2
+  .align    4
+  .data     0x8C008190
+  .data     48
+  .binary   C505338CD405338CC505338CE605338CC505338CF805338CC505338C0A06338CC505338C1C06338CC505338C3082008C
+
+# Add missing map names: map_acave01_05, map_acave03_05, map_amachine01_05, map_amachine02_05
+  .align    4
+  .data     0x8C008200
+  .data     66
+  .binary   6D61705F616361766530315F3035006D61705F616361766530335F3035006D61705F616D616368696E6530315F3035006D61705F616D616368696E6530325F303500
+
+  .align    4
+  .data     0x00000000
+  .data     0x00000000

--- a/system/client-functions/UltimateMapFix/UltimateMapFix.2OJ5.patch.s
+++ b/system/client-functions/UltimateMapFix/UltimateMapFix.2OJ5.patch.s
@@ -1,0 +1,66 @@
+.meta name="Ultimate map fix"
+.meta description="Add missing maps\nto Ultimate for\ncertain quests"
+
+entry_ptr:
+reloc0:
+  .offsetof start
+start:
+  .include  WriteCodeBlocksDC
+
+# Modify location of Ultimate Cave 1 map pointer table to 8C008100 and make it have 6 entries
+  .align    4
+  .data     0x8C32FED0
+  .data     6
+  .binary   0081008C0600
+
+# Modify location of Ultimate Cave 3 map pointer table to 8C008130 and make it have 6 entries
+  .align    4
+  .data     0x8C32FEE0
+  .data     6
+  .binary   3081008C0600
+
+# Modify location of Ultimate Mine 1 map pointer table to 8C008160 and make it have 6 entries
+  .align    4
+  .data     0x8C32FEE8
+  .data     6
+  .binary   6081008C0600
+
+# Modify location of Ultimate Mine 2 map pointer table to 8C008190 and make it have 6 entries
+  .align    4
+  .data     0x8C32FEF0
+  .data     6
+  .binary   9081008C0600
+
+# New map pointer table for Cave 1
+  .align    4
+  .data     0x8C008100
+  .data     48
+  .binary   5704338C6304338C5704338C7204338C5704338C8104338C5704338C9004338C5704338C9F04338C5704338C0082008C
+
+# New map pointer table for Cave 3
+  .align    4
+  .data     0x8C008130
+  .data     48
+  .binary   0505338C1105338C0505338C4D05338C0505338C2F05338C0505338C3E05338C0505338C4D05338C0505338C0F82008C
+
+# New map pointer table for Mine 1
+  .align    4
+  .data     0x8C008160
+  .data     48
+  .binary   5C05338C6B05338C5C05338C7D05338C5C05338C8F05338C5C05338CA105338C5C05338CB305338C5C05338C1E82008C
+
+# New map pointer table for Mine 2
+  .align    4
+  .data     0x8C008190
+  .data     48
+  .binary   C505338CD405338CC505338CE605338CC505338CF805338CC505338C0A06338CC505338C1C06338CC505338C3082008C
+
+# Add missing map names: map_acave01_05, map_acave03_05, map_amachine01_05, map_amachine02_05
+  .align    4
+  .data     0x8C008200
+  .data     66
+  .binary   6D61705F616361766530315F3035006D61705F616361766530335F3035006D61705F616D616368696E6530315F3035006D61705F616D616368696E6530325F303500
+
+  .align    4
+  .data     0x00000000
+  .data     0x00000000

--- a/system/client-functions/UltimateMapFix/UltimateMapFix.2OJF.patch.s
+++ b/system/client-functions/UltimateMapFix/UltimateMapFix.2OJF.patch.s
@@ -1,0 +1,66 @@
+.meta name="Ultimate map fix"
+.meta description="Add missing maps\nto Ultimate for\ncertain quests"
+
+entry_ptr:
+reloc0:
+  .offsetof start
+start:
+  .include  WriteCodeBlocksDC
+
+# Modify location of Ultimate Cave 1 map pointer table to 8C008100 and make it have 6 entries
+  .align    4
+  .data     0x8C32D638
+  .data     6
+  .binary   0081008C0600
+
+# Modify location of Ultimate Cave 3 map pointer table to 8C008130 and make it have 6 entries
+  .align    4
+  .data     0x8C32D648
+  .data     6
+  .binary   3081008C0600
+
+# Modify location of Ultimate Mine 1 map pointer table to 8C008160 and make it have 6 entries
+  .align    4
+  .data     0x8C32D650
+  .data     6
+  .binary   6081008C0600
+
+# Modify location of Ultimate Mine 2 map pointer table to 8C008190 and make it have 6 entries
+  .align    4
+  .data     0x8C32D658
+  .data     6
+  .binary   9081008C0600
+
+# New map pointer table for Cave 1
+  .align    4
+  .data     0x8C008100
+  .data     48
+  .binary   BFDB328CCBDB328CBFDB328CDADB328CBFDB328CE9DB328CBFDB328CF8DB328CBFDB328C07DC328CBFDB328C0082008C
+
+# New map pointer table for Cave 3
+  .align    4
+  .data     0x8C008130
+  .data     48
+  .binary   6DDC328C79DC328C6DDC328C88DC328C6DDC328C97DC328C6DDC328CA6DC328C6DDC328CB5DC328C6DDC328C0F82008C
+
+# New map pointer table for Mine 1
+  .align    4
+  .data     0x8C008160
+  .data     48
+  .binary   C4DC328CD3DC328CC4DC328CE5DC328CC4DC328CF7DC328CC4DC328C09DD328CC4DC328C1BDD328CC4DC328C1E82008C
+
+# New map pointer table for Mine 2
+  .align    4
+  .data     0x8C008190
+  .data     48
+  .binary   2DDD328C3CDD328C2DDD328C4EDD328C2DDD328C60DD328C2DDD328C72DD328C2DDD328C84DD328C2DDD328C3082008C
+
+# Add missing map names: map_acave01_05, map_acave03_05, map_amachine01_05, map_amachine02_05
+  .align    4
+  .data     0x8C008200
+  .data     66
+  .binary   6D61705F616361766530315F3035006D61705F616361766530335F3035006D61705F616D616368696E6530315F3035006D61705F616D616368696E6530325F303500
+
+  .align    4
+  .data     0x00000000
+  .data     0x00000000

--- a/system/client-functions/UltimateMapFix/UltimateMapFix.2OPF.patch.s
+++ b/system/client-functions/UltimateMapFix/UltimateMapFix.2OPF.patch.s
@@ -1,0 +1,66 @@
+.meta name="Ultimate map fix"
+.meta description="Add missing maps\nto Ultimate for\ncertain quests"
+
+entry_ptr:
+reloc0:
+  .offsetof start
+start:
+  .include  WriteCodeBlocksDC
+
+# Modify location of Ultimate Cave 1 map pointer table to 8C008100 and make it have 6 entries
+  .align    4
+  .data     0x8C3244A8
+  .data     6
+  .binary   0081008C0600
+
+# Modify location of Ultimate Cave 3 map pointer table to 8C008130 and make it have 6 entries
+  .align    4
+  .data     0x8C3244B8
+  .data     6
+  .binary   3081008C0600
+
+# Modify location of Ultimate Mine 1 map pointer table to 8C008160 and make it have 6 entries
+  .align    4
+  .data     0x8C3244C0
+  .data     6
+  .binary   6081008C0600
+
+# Modify location of Ultimate Mine 2 map pointer table to 8C008190 and make it have 6 entries
+  .align    4
+  .data     0x8C3244C8
+  .data     6
+  .binary   9081008C0600
+
+# New map pointer table for Cave 1
+  .align    4
+  .data     0x8C008100
+  .data     48
+  .binary   2F4A328C3B4A328C2F4A328C4A4A328C2F4A328C594A328C2F4A328C684A328C2F4A328C774A328C2F4A328C0082008C
+
+# New map pointer table for Cave 3
+  .align    4
+  .data     0x8C008130
+  .data     48
+  .binary   DD4A328CE94A328CDD4A328CF84A328CDD4A328C074B328CDD4A328C164B328CDD4A328C254B328CDD4A328C0F82008C
+
+# New map pointer table for Mine 1
+  .align    4
+  .data     0x8C008160
+  .data     48
+  .binary   344B328C434B328C344B328C554B328C344B328C674B328C344B328C794B328C344B328C8B4B328C344B328C1E82008C
+
+# New map pointer table for Mine 2
+  .align    4
+  .data     0x8C008190
+  .data     48
+  .binary   9D4B328CAC4B328C9D4B328CBE4B328C9D4B328CD04B328C9D4B328CE24B328C9D4B328CF44B328C9D4B328C3082008C
+
+# Add missing map names: map_acave01_05, map_acave03_05, map_amachine01_05, map_amachine02_05
+  .align    4
+  .data     0x8C008200
+  .data     66
+  .binary   6D61705F616361766530315F3035006D61705F616361766530335F3035006D61705F616D616368696E6530315F3035006D61705F616D616368696E6530325F303500
+
+  .align    4
+  .data     0x00000000
+  .data     0x00000000


### PR DESCRIPTION
This patch adds the missing maps into Ultimate on DCv2: Cave 1-5, Cave 3-5, Mine 1-5, Mine 2-5. This is mostly important for the official Famitsu Maximum Attack quest, but there may be other custom quests which use these maps too.

I originally tried to put the new data in an empty space in the executable, but this didn't seem to work as half the time the maps would not load at all, so I assume that space is actually used in RAM. I put it into the bootsector which I believe is untouched after talking to some others, so this should be safe.