### PR TITLE
DCV2 patch to enable rares dropping in quests

### DIFF
--- a/system/client-functions/RaresInQuests/RaresInQuests.2OEF.patch.s
+++ b/system/client-functions/RaresInQuests/RaresInQuests.2OEF.patch.s
@@ -1,0 +1,22 @@
+.meta name="Rares in quests"
+.meta description="Disables logic that\nprevents items\nabove 8 stars and\nrares from dropping\nin quests."
+
+entry_ptr:
+reloc0:
+  .offsetof start
+start:
+  .include  WriteCodeBlocksDC
+
+  .align    4
+  .data     0x8C21A28C
+  .data     2
+  nop
+
+    .align    4
+  .data     0x8C21A300
+  .data     2
+  nop
+
+  .align    4
+  .data     0x00000000
+  .data     0x00000000

--- a/system/client-functions/RaresInQuests/RaresInQuests.2OJF.patch.s
+++ b/system/client-functions/RaresInQuests/RaresInQuests.2OJF.patch.s
@@ -1,0 +1,22 @@
+.meta name="Rares in quests"
+.meta description="Disables logic that\nprevents items\nabove 8 stars and\nrares from dropping\nin quests."
+
+entry_ptr:
+reloc0:
+  .offsetof start
+start:
+  .include  WriteCodeBlocksDC
+
+  .align    4
+  .data     0x8C2192C8
+  .data     2
+  nop
+
+    .align    4
+  .data     0x8C219254
+  .data     2
+  nop
+
+  .align    4
+  .data     0x00000000
+  .data     0x00000000

--- a/system/client-functions/RaresInQuests/RaresInQuests.2OPF.patch.s
+++ b/system/client-functions/RaresInQuests/RaresInQuests.2OPF.patch.s
@@ -1,0 +1,22 @@
+.meta name="Rares in quests"
+.meta description="Disables logic that\nprevents items\nabove 8 stars and\nrares from dropping\nin quests."
+
+entry_ptr:
+reloc0:
+  .offsetof start
+start:
+  .include  WriteCodeBlocksDC
+
+  .align    4
+  .data     0x8C219E6C
+  .data     2
+  nop
+
+    .align    4
+  .data     0x8C219DF8
+  .data     2
+  nop
+
+  .align    4
+  .data     0x00000000
+  .data     0x00000000


### PR DESCRIPTION
A patch for all final v2 versions to enable rares and items above 8 stars to drop in quests.