### PR TITLE
[59NL] Change hungry mag sound effect

### DIFF
--- a/system/client-functions/HungryMagSound/HungryMagSound.59NL.patch.s
+++ b/system/client-functions/HungryMagSound/HungryMagSound.59NL.patch.s
@@ -19,7 +19,7 @@ patch_code:
   push      0
   push      0
   push      0
-  push      0x0576
+  push      0xAC
   mov       eax, 0x00814298
   call      eax
   add       esp, 0x10


### PR DESCRIPTION
Change the hungry mag sound effect from "message received" to "mag feed".
This is how it is on Ephinea and in my opinion makes more sense.

The "mag feed" sound activates the correct neurons. See image for reference
![image](https://github.com/user-attachments/assets/41646a6b-0da9-4dad-a087-f626105778f1)

From this "message received"

[Sample 189.webm](https://github.com/user-attachments/assets/6e692ea6-3848-4a61-83da-d8affe3c8ecf)

To this "mag feed"

[Sample 169.webm](https://github.com/user-attachments/assets/fd7bef4f-4ec8-4b20-90f7-72cb9880e81d)
