### PR TITLE
Fix HTTP Endpoint Logic

### DIFF
--- a/src/HTTPServer.cc
+++ b/src/HTTPServer.cc
@@ -798,7 +798,7 @@ asio::awaitable<std::unique_ptr<HTTPResponse>> HTTPServer::handle_request(shared
     } else if (req.path == "/y/data/rare-tables") {
       this->require_GET(req);
       ret = this->generate_rare_table_list_json();
-    } else if (!req.path.starts_with("/y/data/rare-tables/")) {
+    } else if (req.path.starts_with("/y/data/rare-tables/")) {
       this->require_GET(req);
       ret = co_await this->generate_rare_table_json(req.path.substr(20));
     } else if (req.path == "/y/data/quests") {


### PR DESCRIPTION
`(!req.path.starts_with("/y/data/rare-tables/"))` was causing every subsequent command to be processed as a rare-tables substring command thanks to the erroneous `!`.

This made fun requests such as this totally valid `/y/ilikehappycatsyayrare-table-v4` :)

**Testing:**
- `/y/summary` now works correctly, as do other GET requests
- Rare table endpoints still function as expected with both `/y/data/rare-tables` and `/y/data/rare-tables/` working
- Tested on Alpine linux