### PR TITLE
document the original unit stars random state

### DIFF
--- a/src/ItemCreator.hh
+++ b/src/ItemCreator.hh
@@ -96,7 +96,7 @@ private:
   //   [0x0B] - unit modifiers
   //   [0x0C] - common armor DFP bonuses
   //   [0x0D] - common armor EVP bonuses
-  //   [0x0E] - apparently unused
+  //   [0x0E] - unit stars
   //   [0x0F] - which common weapon special to generate
   //   [0x10] - apparently unused
   std::shared_ptr<RandomGenerator> rand_crypt;


### PR DESCRIPTION
"random state 0xe" is referenced from 0x80106aec (US1.0) and is used to decide how many stars the generated unit will have.