### PR TITLE
Assemble the fleti instruction properly

### DIFF
--- a/src/QuestScript.cc
+++ b/src/QuestScript.cc
@@ -4496,7 +4496,7 @@ AssembledQuestScript assemble_quest_script(
                   code_w.put_u32l(stoll(arg, nullptr, 0));
                   break;
                 case Type::FLOAT32:
-                  code_w.put_u32l(stof(arg, nullptr));
+                  code_w.put_f32l(stof(arg, nullptr));
                   break;
                 case Type::CSTRING:
                   if (arg.starts_with("bin:")) {


### PR DESCRIPTION
* Fixes #696

This fixes the `fleti` instruction not being assembled correctly causing the values to not being right in the quest while running.

However, since the instruction is used in V3 clients, I'm not sure if this breaks them. I don't have a V3 client to test unfortunately.

This was tested as working on BB from my side.