### PR TITLE
Port all 59NL/59NJ patches to 50YJ (US 1.24.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ The specific versions are:
 | PSO Xbox US TU               | 4OEU | x86                            |
 | PSO Xbox EU Disc             | 4OPD | x86                            |
 | PSO Xbox EU TU               | 4OPU | x86                            |
+| PSO BB US 1.24.3             | 50YJ | x86                            |
 | PSO BB JP 1.25.11            | 59NJ | x86                            |
 | PSO BB JP 1.25.13            | 59NL | x86                            |
 | PSO BB Tethealla             | 59NL | x86                            |

--- a/notes/ar-codes.txt
+++ b/notes/ar-codes.txt
@@ -41,6 +41,7 @@ Version codes (from README.md):
   4OEU: PSO Xbox US TU
   4OPD: PSO Xbox EU Disc
   4OPU: PSO Xbox EU TU
+  50YJ: PSO BB US 1.24.3
   59NJ: PSO BB JP 1.25.11
   59NL: PSO BB JP 1.25.13 (including the Tethealla client)
 
@@ -81,6 +82,7 @@ Disable item equip restrictions ("God of equip")
 3OJ5 => 041050D4 38000005
 3OJT => 0415BF50 38000005
 3OP0 => 041052D4 38000005
+5OYJ => 005C8C8F E9A7000000
 59NJ => 005C9F35 E9A7000000
 59NL => 005C9F31 E9A7000000
 
@@ -88,6 +90,7 @@ All items visible in Pioneer 2
 3OE1 => 04102D88 38600000
 
 Mags visible in Pioneer 2
+5OYJ => 005D7053 EB04
 59NJ => 005D8F27 EB04
 59NL => 005D8F4B EB04
 
@@ -96,6 +99,9 @@ Disable pause menu background + offset
         0428735C 4800000C
 3OE2 => 0424CED8 48000370
         042887D8 4800000C
+5OYJ => 00713758 9090
+        0072D417 9090
+        0072D27E 90E9
 59NJ => 00719C58 9090
         00733C57 9090
         00733ABE 90E9
@@ -642,6 +648,8 @@ Fast tekker (skips wind-up jingle)
         0023EF77 jmp    +0x0A
 4OPU => 0023F14C mov    dword [ebp + 0x14C], 1
         0023F167 jmp    +0x0A
+5OYJ => 006D3F7B mov    dword [edi + 0x14C], 1
+        006D3F98 jmp    +0x0B
 59NJ => 006DA14B mov    dword [edi + 0x14C], 1
         006DA168 jmp    +0x0B
 59NL => 006DA113 mov    dword [edi + 0x14C], 1
@@ -980,6 +988,8 @@ Override Challenge mode random enemy location tables limit
 4OEU => 002E742C XXXXXXXX (count as little-endian dword)
 4OPD => 002E720C XXXXXXXX (count as little-endian dword)
 4OPU => 002E745C XXXXXXXX (count as little-endian dword)
+5OYJ => 008075C3 XXXXXXXX (count * 4 as little-endian dword)
+        008075DC XXXXXXXX (count as little-endian dword)
 59NJ => 0080FA3F XXXXXXXX (count * 4 as little-endian dword)
         0080FA58 XXXXXXXX (count as little-endian dword)
 59NL => 0080ECB7 XXXXXXXX (count * 4 as little-endian dword)

--- a/notes/psobb/psobb-50YJ-US1.24.3.txt
+++ b/notes/psobb/psobb-50YJ-US1.24.3.txt
@@ -1,0 +1,73 @@
+########################################################################
+                	        DOWNLOAD
+########################################################################
+
+The official installer for this client is seemingly lost to time.
+However, we do still have access to a download link to a directory of
+the game client. Located at the bottom of this post:
+https://github.com/fuzziqersoftware/newserv/discussions/734
+
+The correct client exe to use, would be PsoBB.pat inside the
+"3. PSOBB Executable" directory. While the file extension is .pat, it
+can be renamed and changed to .exe .
+
+However, PsoBB.exe in its current state will not work on its own.
+As it is packed with a version of ASProtect. Which will impede you from
+removing GameGuard, as well as modifying the client to connect to a desired
+IP address.
+
+There are two ways around this.
+
+1. Use a code injection dll
+2. Unpack the exe
+
+As far as I know, There is currently not any code injection dll projects
+available for use with this client. So our main option is going to be
+unpacking the client.
+
+There are several ways to unpack a client. For the sake of simplicity, we
+will use a automated program. 
+Something like:
+https://github.com/Hendi48/ASpirin
+Originally found in this issue:
+https://github.com/fuzziqersoftware/newserv/issues/748
+
+You will know the process was successful if the new resulting exe file
+has a much larger file size than the original.
+
+########################################################################
+                	    REMOVE GAMEGUARD
+########################################################################
+
+The first step in being able to use this client, is removing GameGuard.
+
+In order to do this, we will prevent GameGuard from initializing by
+forcing the responsible function to return.
+
+00844A9C - ret (or C3 in hex)
+
+This will effectively stop GameGuard from ever starting.
+However, the client has checks on startup to see if GameGuard is running,
+and will close the game if it detects otherwise.
+
+008444BB - jmp 008444DD
+
+Now there is nothing in the way from starting up the game.
+Find and edit the client's IP addresses, and have fun.
+
+
+########################################################################
+                	         NOTES
+########################################################################
+
+Despite being a US client primarily using english, the client seems to
+still have a reliance on having Japanese-IME enabled.
+You can get around any kind of issue with this by patching out the need
+for IME.
+
+008582CC - call dword ptr ds:[0x008E0228]
+
+Alternatively, in a hex editor, you can search for:
+"EB 1A 6A 00 FF 15 9C C3"
+Once found, replace with:
+"EB 1A 6A 00 FF 15 28 02"

--- a/notes/psobb/psobb-notes.txt
+++ b/notes/psobb/psobb-notes.txt
@@ -3,7 +3,7 @@ PSOBB SUPPORT FILES, NOTES & RESOURCES
 --------------------------------------------------------------------------------
 CLIENT LOCALIZATION
 
-By default PSOBB loads everything in Japanese so it requires some extra files
+By default PSOBB JP clients load everything in Japanese so it requires some extra files
 to properly implement the English localization from SOA, these files are offered
 here inside the usbb-resources folder for your convenience they are the same ones
 from the old official USBB client

--- a/src/CommandFormats.hh
+++ b/src/CommandFormats.hh
@@ -5747,7 +5747,7 @@ struct G_ChangeLobbyMusic_Ep3_6xBF {
 // 6xBF: Give EXP (BB) (server->client only)
 // newserv implements an extension that causes this command to show the purple EXP numbers which are normally generated
 // by the client instead. This requires the server to also send the enemy ID that generated the EXP, hence the
-// extension struct here. See ServerEXPDisplay.59NL.patch.s for details.
+// extension struct here. See ServerEXPDisplay.s for details.
 
 struct G_GiveExperience_BB_6xBF {
   G_ClientIDHeader header;

--- a/system/client-functions/AccurateKillCount.s
+++ b/system/client-functions/AccurateKillCount.s
@@ -69,11 +69,11 @@ TItemWeapon_SealedJSword_count_kill_end:
 
 
 
-  .versions 59NJ 59NL
+  .versions 50YJ 59NJ 59NL
 
-  .data     <VERS 0x005E32A4 0x005E32C8>
+  .data     <VERS 0x005E0324 0x005E32A4 0x005E32C8>
   .deltaof  TItemUnitUnsealable_count_kill, TItemUnitUnsealable_count_kill_end
-  .address  <VERS 0x005E32A4 0x005E32C8>
+  .address  <VERS 0x005E0324 0x005E32A4 0x005E32C8>
 TItemUnitUnsealable_count_kill:  # [std] (TItemUnitUnsealable* this @ ecx) -> void
   mov       eax, [ecx + 0xF8]
   movsx     eax, word [eax + 0x11A]  # eax = this->owner_player->num_kills_since_map_load
@@ -91,12 +91,12 @@ TItemUnitUnsealable_count_kill_skip_update:
   setae     dh
   shl       edx, 1
   or        dword [ecx + 0xDC], edx
-  jmp       <VERS 0x005E2C10 0x005E2C34>
+  jmp       <VERS 0x005DFDAC 0x005E2C10 0x005E2C34>
 TItemUnitUnsealable_count_kill_end:
 
-  .data     <VERS 0x005F3E94 0x005F3EFC>
+  .data     <VERS 0x005EFF28 0x005F3E94 0x005F3EFC>
   .deltaof  TItemWeapon_LameDArgent_count_kill, TItemWeapon_LameDArgent_count_kill_end
-  .address  <VERS 0x005F3E94 0x005F3EFC>
+  .address  <VERS 0x005EFF28 0x005F3E94 0x005F3EFC>
 TItemWeapon_LameDArgent_count_kill:
   mov       eax, [ecx + 0xF8]
   movsx     eax, word [eax + 0x11A]
@@ -117,9 +117,9 @@ TItemWeapon_LameDArgent_count_kill_skip_update:
   ret
 TItemWeapon_LameDArgent_count_kill_end:
 
-  .data     <VERS 0x005FC95C 0x005FCA74>
+  .data     <VERS 0x005F872C 0x005FC95C 0x005FCA74>
   .deltaof  TItemWeapon_SealedJSword_count_kill, TItemWeapon_SealedJSword_count_kill_end
-  .address  <VERS 0x005FC95C 0x005FCA74>
+  .address  <VERS 0x005F872C 0x005FC95C 0x005FCA74>
 TItemWeapon_SealedJSword_count_kill:
   mov       eax, [ecx + 0xF8]
   movsx     eax, word [eax + 0x11A]

--- a/system/client-functions/BlueBurstExclusive/BankSize.s
+++ b/system/client-functions/BlueBurstExclusive/BankSize.s
@@ -10,7 +10,7 @@
 .meta name="More bank slots"
 .meta description=""
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
@@ -19,80 +19,80 @@ reloc0:
 start:
   .include WriteCodeBlocks
 
-  .data    <VERS 0x006C8C53 0x006C8C0F>
+  .data    <VERS 0x006C2AAF 0x006C8C53 0x006C8C0F>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006C8C91 0x006C8C4D>
+  .data    <VERS 0x006C2B0D 0x006C8C91 0x006C8C4D>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006C8B98 0x006C8B54>
+  .data    <VERS 0x006C2A02 0x006C8B98 0x006C8B54>
   .data    4
   .data    999  # slot count - 1
-  .data    <VERS 0x006C8BD8 0x006C8B94>
+  .data    <VERS 0x006C2A42 0x006C8BD8 0x006C8B94>
   .data    4
   .data    0x5DC0  # data size - 8
-  .data    <VERS 0x006C8D5A 0x006C8D16>
+  .data    <VERS 0x006C2BA2 0x006C8D5A 0x006C8D16>
   .data    4
   .data    999  # slot count - 1
-  .data    <VERS 0x006C8EA2 0x006C8E5E>
+  .data    <VERS 0x006C2D02 0x006C8EA2 0x006C8E5E>
   .data    4
   .data    999  # slot count - 1
-  .data    <VERS 0x006C8F70 0x006C8F2C>
+  .data    <VERS 0x006C2DD0 0x006C8F70 0x006C8F2C>
   .data    4
   .data    999  # slot count - 1
-  .data    <VERS 0x006C905A 0x006C9016>
+  .data    <VERS 0x006C2EBA 0x006C905A 0x006C9016>
   .data    4
   .data    0x5DB0  # data size - 0x18
-  .data    <VERS 0x006C9078 0x006C9034>
+  .data    <VERS 0x006C2ED8 0x006C9078 0x006C9034>
   .data    4
   .data    0x5DC0  # data size - 8
-  .data    <VERS 0x006C9151 0x006C910D>
+  .data    <VERS 0x006C2FB1 0x006C9151 0x006C910D>
   .data    4
   .data    0x5DB0  # data size - 0x18
-  .data    <VERS 0x006C916D 0x006C9129>
+  .data    <VERS 0x006C2FCD 0x006C916D 0x006C9129>
   .data    4
   .data    0x5DC8  # data size
-  .data    <VERS 0x006C927A 0x006C9236>
+  .data    <VERS 0x006C30DA 0x006C927A 0x006C9236>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006C9290 0x006C924C>
+  .data    <VERS 0x006C30F0 0x006C9290 0x006C924C>
   .data    4
   .data    999  # slot count - 1
-  .data    <VERS 0x006C92CA 0x006C9286>
+  .data    <VERS 0x006C312A 0x006C92CA 0x006C9286>
   .data    4
   .data    999  # slot count - 1
-  .data    <VERS 0x006C933E 0x006C92FA>
+  .data    <VERS 0x006C319E 0x006C933E 0x006C92FA>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006C98C7 0x006C9883>
+  .data    <VERS 0x006C3727 0x006C98C7 0x006C9883>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006C9A66 0x006C9A22>
+  .data    <VERS 0x006C38C6 0x006C9A66 0x006C9A22>
   .data    4
   .data    2000000000  # max meseta
-  .data    <VERS 0x006CA31F 0x006CA2DB>
+  .data    <VERS 0x006C417F 0x006CA31F 0x006CA2DB>
   .data    4
   .data    0x5DC8  # data size
-  .data    <VERS 0x006CA347 0x006CA303>
+  .data    <VERS 0x006C41A7 0x006CA347 0x006CA303>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006CA3C3 0x006CA37F>
+  .data    <VERS 0x006C4223 0x006CA3C3 0x006CA37F>
   .data    4
   .data    0x5DC8  # data size
-  .data    <VERS 0x006D7DC4 0x006D7DAC>
+  .data    <VERS 0x006D1BD8 0x006D7DC4 0x006D7DAC>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006D7DD5 0x006D7DBD>
+  .data    <VERS 0x006D1BE9 0x006D7DD5 0x006D7DBD>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006D7E2C 0x006D7E14>
+  .data    <VERS 0x006D1C40 0x006D7E2C 0x006D7E14>
   .data    4
   .data    1000  # slot count
-  .data    <VERS 0x006D7C0D 0x006D7BF5>
+  .data    <VERS 0x006D1A21 0x006D7C0D 0x006D7BF5>
   .data    4
   .data    1000  # slot count
 
-  .data    <VERS 0x006C8E03 0x006C8DBF>
+  .data    <VERS 0x006C2C63 0x006C8E03 0x006C8DBF>
   .data    2
   jmp      +0x27
 

--- a/system/client-functions/BlueBurstExclusive/ClassicMainWarpBehavior.s
+++ b/system/client-functions/BlueBurstExclusive/ClassicMainWarpBehavior.s
@@ -7,23 +7,23 @@
 .meta name="Classic main warp behavior"
 .meta description=""
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
   .offsetof start
 start:
   .include  WriteCodeBlocks
-  .data     <VERS 0x0064A642 0x0064A5DE>  # Episode 1
+  .data     <VERS 0x0064527E 0x0064A642 0x0064A5DE>  # Episode 1
   .data     1
   .binary   01
-  .data     <VERS 0x0064A4AC 0x0064A448>  # Episode 2
+  .data     <VERS 0x006450E8 0x0064A4AC 0x0064A448>  # Episode 2
   .data     2
   .binary   0100
-  .data     <VERS 0x0064A58D 0x0064A529>  # Episode 4
+  .data     <VERS 0x006451C9 0x0064A58D 0x0064A529>  # Episode 4
   .data     1
   .binary   01
-  .data     <VERS 0x0064A6BC 0x0064A658>  # Non-Normal difficulty check
+  .data     <VERS 0x006452F8 0x0064A6BC 0x0064A658>  # Non-Normal difficulty check
   .data     2
   nop
   nop

--- a/system/client-functions/BlueBurstExclusive/ClearUnreleasedItemList.s
+++ b/system/client-functions/BlueBurstExclusive/ClearUnreleasedItemList.s
@@ -7,7 +7,7 @@
 .meta name="Clear unreleased item list"
 .meta description=""
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
@@ -15,7 +15,7 @@ reloc0:
 start:
   xor       eax, eax
   mov       edx, esp
-  mov       esp, <VERS 0x009F61B0 0x009F81B0>
+  mov       esp, <VERS 0x009EC359 0x009F61B0 0x009F81B0>
   mov       ecx, 0x3C
 again:
   push      0

--- a/system/client-functions/BlueBurstExclusive/MomokaItemExchangeFix.s
+++ b/system/client-functions/BlueBurstExclusive/MomokaItemExchangeFix.s
@@ -2,7 +2,7 @@
 .meta name="Item exch. fix"
 .meta description="Fixes some quest item\nexchange opcodes"
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
@@ -13,7 +13,7 @@ start:
 
 
   # Fix 6xDE failure label truncation
-  .data     <VERS 0x006B911E 0x006B90DE>
+  .data     <VERS 0x006B2FEA 0x006B911E 0x006B90DE>
   .data     1
   .binary   03
 
@@ -21,23 +21,23 @@ start:
 
   # Fix send_6xD9 not setting size field
 
-  .data     <VERS 0x006CA584 0x006CA540>
+  .data     <VERS 0x006C43CC 0x006CA584 0x006CA540>
   .deltaof  send_6xD9_start, send_6xD9_end
-  .address  <VERS 0x006CA584 0x006CA540>
+  .address  <VERS 0x006C43CC 0x006CA584 0x006CA540>
 send_6xD9_start:  # [std](void* this @ ecx) -> void
   push      ebx
   mov       ebx, ecx
   push      0  # cmd.success_label, cmd.failure_label
-  mov       eax, [<VERS 0x00A9A074 0x00A9C4F4>]  # local_client_id
+  mov       eax, [<VERS 0x00A90034 0x00A9A074 0x00A9C4F4>]  # local_client_id
   xor       eax, 1
   push      eax  # cmd.token2
   mov       ecx, [ebx + 0x2C]
-  call      <VERS 0x00737E80 0x00737D90>  # [std](void* this @ ecx = *(this + 0x2C)) -> void* @ eax
+  call      <VERS 0x00731494 0x00737E80 0x00737D90>  # [std](void* this @ ecx = *(this + 0x2C)) -> void* @ eax
   mov       edx, [ebx + 0x3C]
   imul      eax, eax, 0x14
   add       edx, eax
   mov       eax, [edx + 0x10]
-  xor       eax, [<VERS 0x00A9A074 0x00A9C4F4>]  # local_client_id
+  xor       eax, [<VERS 0x00A90034 0x00A9A074 0x00A9C4F4>]  # local_client_id
   push      eax  # cmd.token1
   push      dword [edx + 0x10]  # cmd.replace_item.data2d
   push      dword [edx + 0x0C]  # cmd.replace_item.id
@@ -52,12 +52,12 @@ send_6xD9_start:  # [std](void* this @ ecx) -> void
   push      0x00000ED9  # cmd.header
 
   mov       ecx, esp
-  call      <VERS 0x00801150 0x008003E0>  # send_and_handle_60[std](void* cmd @ ecx) -> void
+  call      <VERS 0x007F9160 0x00801150 0x008003E0>  # send_and_handle_60[std](void* cmd @ ecx) -> void
   add       esp, 0x38
 
   mov       dword [ebx + 0x20], 6
   push      0
-  call      <VERS 0x0083746D 0x00859D2D>  # time[std](void* t @ [esp + 4] = nullptr) -> uint32_t @ eax
+  call      <VERS 0x0082E1ED 0x0083746D 0x00859D2D>  # time[std](void* t @ [esp + 4] = nullptr) -> uint32_t @ eax
   add       esp, 4
   mov       [ebx + 0x5C], eax
 
@@ -69,16 +69,16 @@ send_6xD9_end:
 
   # Same fix as above, but for quest_F95B_send_6xD9
 
-  .data     <VERS 0x006B9058 0x006B9018>
+  .data     <VERS 0x006B2F24 0x006B9058 0x006B9018>
   .deltaof  quest_F95B_send_6xD9_start, quest_F95B_send_6xD9_end
-  .address  <VERS 0x006B9058 0x006B9018>
+  .address  <VERS 0x006B2F24 0x006B9058 0x006B9018>
 quest_F95B_send_6xD9_start:  # [std]() -> void
-  mov       edx, <VERS 0x00A9304C 0x00A954CC>  # quest_args_list
+  mov       edx, <VERS 0x00A8908C 0x00A9304C 0x00A954CC>  # quest_args_list
   mov       ax, [edx + 0x14]  # quest_args_list[5] (failure_label)
   shl       eax, 0x10
   mov       ax, [edx + 0x10]  # quest_args_list[4] (success_label)
   push      eax  # cmd.success_label, cmd.failure_label
-  mov       ecx, [<VERS 0x00A9A074 0x00A9C4F4>]  # local_client_id
+  mov       ecx, [<VERS 0x00A90034 0x00A9A074 0x00A9C4F4>]  # local_client_id
   mov       eax, [edx + 0x0C]  # quest_args_list[3] (token2)
   xor       eax, ecx
   push      eax  # cmd.token2
@@ -107,7 +107,7 @@ quest_F95B_send_6xD9_start:  # [std]() -> void
   push      eax  # cmd.header
 
   mov       ecx, esp
-  call      <VERS 0x00801150 0x008003E0>  # send_and_handle_60[std](void* cmd @ ecx) -> void
+  call      <VERS 0x007F9160 0x00801150 0x008003E0>  # send_and_handle_60[std](void* cmd @ ecx) -> void
   add       esp, 0x38
   ret
 quest_F95B_send_6xD9_end:

--- a/system/client-functions/BlueBurstExclusive/MoreSaveSlots.s
+++ b/system/client-functions/BlueBurstExclusive/MoreSaveSlots.s
@@ -18,7 +18,7 @@
 .meta name="More save slots"
 .meta description=""
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
@@ -52,7 +52,7 @@ start:
 apply_enable_scroll_patch:
   # This patch enables scrolling behavior within the character list
   push      -5          # Jump size (negative = jmp instead of call)
-  push      <VERS 0x00413B77 0x00413B7F>  # Jump address
+  push      <VERS 0x0041370B 0x00413B77 0x00413B7F>  # Jump address
   call      get_code_size_for_enable_scroll
   .deltaof  enable_scroll_start, enable_scroll_end
 get_code_size_for_enable_scroll:
@@ -62,7 +62,7 @@ get_code_size_for_enable_scroll:
 enable_scroll_start:
   mov       eax, dword ptr [edi + 0x28]  # cursor = char_select_menu->cursor_obj (TAdSelectCurGC*)
   or        dword [eax + 0x01F8], 3  # cursor->flags |= 3  # Enable scrolling
-  mov       eax, [<VERS 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
+  mov       eax, [<VERS 0x00A2EC50 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
   mov       ecx, [eax + 0xEC]  # ecx = scroll_bar->client_id
   imul      ecx, ecx, 0x24
   # Set up scroll bar graphics (in struct at scroll_bar + 0x1C)
@@ -93,7 +93,7 @@ enable_scroll_end:
 apply_fix_scroll_patch1:
   # This patch fixes character selection cursor object so it will take the scroll offset into account
   push      6           # Call size
-  push      <VERS 0x00413C30 0x00413C38>  # Call address
+  push      <VERS 0x004137C4 0x00413C30 0x00413C38>  # Call address
   call      get_code_size_for_fix_scroll_patch1
   .deltaof  fix_scroll_patch1_start, fix_scroll_patch1_end
 get_code_size_for_fix_scroll_patch1:
@@ -103,7 +103,7 @@ get_code_size_for_fix_scroll_patch1:
 fix_scroll_patch1_start:
   mov       edx, [edi + 0x28]  # cursor = this->ad_select_cur_obj (TAdSelectCurGC*)
   mov       ebp, [edx + 0x44]  # ebp = cursor->selected_index_within_view
-  mov       eax, [<VERS 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
+  mov       eax, [<VERS 0x00A2EC50 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
   add       ebp, [eax + 0xAC]  # ebp += scroll_bar->selection_state[0].scroll_offset
   ret
 fix_scroll_patch1_end:
@@ -116,7 +116,7 @@ apply_fix_scroll_patch2:
   # This patch changes the TAdSinglePlyChrSelectGC::selected_index_within_view to be the selected character's absolute
   # index (including scroll_offset), not the index only within the displayed four characters
   push      6           # Call size
-  push      <VERS 0x00413CD0 0x00413CD8>  # Call address
+  push      <VERS 0x00413864 0x00413CD0 0x00413CD8>  # Call address
   call      get_code_size_for_fix_scroll_patch2
   .deltaof  fix_scroll_patch2_start, fix_scroll_patch2_end
 get_code_size_for_fix_scroll_patch2:
@@ -124,7 +124,7 @@ get_code_size_for_fix_scroll_patch2:
   push      dword [eax]
   call      fix_scroll_patch2_end
 fix_scroll_patch2_start:
-  mov       eax, [<VERS 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
+  mov       eax, [<VERS 0x00A2EC50 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
   mov       eax, [eax + 0xAC]  # eax = scroll_bar->selection_state[0].scroll_offset
   mov       edx, [edi + 0x28]  # cursor = this->ad_select_cur_obj (TAdSelectCurGC*)
   add       eax, [edx + 0x44]  # eax += cursor->selected_index_within_view
@@ -138,7 +138,7 @@ fix_scroll_patch2_end:
 apply_fix_file_index:
   # This patch fixes the character file indexing so it will account for the scroll position
   push      5           # Call size
-  push      <VERS 0x00413CE8 0x00413CF0>  # Call address
+  push      <VERS 0x0041387C 0x00413CE8 0x00413CF0>  # Call address
   call      get_code_size_for_selection_index_fix2
   .deltaof  selection_index_fix2_start, selection_index_fix2_end
 get_code_size_for_selection_index_fix2:
@@ -146,11 +146,11 @@ get_code_size_for_selection_index_fix2:
   push      dword [eax]
   call      selection_index_fix2_end
 selection_index_fix2_start:
-  mov       eax, [<VERS 0x00A38BD0 0x00A3B050>]
+  mov       eax, [<VERS 0x00A2EC50 0x00A38BD0 0x00A3B050>]
   mov       eax, [eax + 0xAC]  # eax = TAdScrollBarXb_objs[0]->selection_state[0].scroll_offset
   add       ebp, eax  # arg0 += eax
   mov       [esp + 4], ebp
-  mov       eax, <VERS 0x006C1ABC 0x006C1A80>
+  mov       eax, <VERS 0x006BB954 0x006C1ABC 0x006C1A80>
   jmp       eax  # set_current_char_slot
 selection_index_fix2_end:
   call      write_call_to_code
@@ -169,10 +169,10 @@ get_code_size_for_preview_window_fix:
   push      dword [eax]
   call      preview_window_fix_end
 preview_window_fix_start:
-  mov       eax, [<VERS 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
+  mov       eax, [<VERS 0x00A2EC50 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
   mov       eax, [eax + 0xAC]  # eax = scroll_bar->selection_state[0].scroll_offset
   add       [esp + 4], eax
-  mov       eax, <VERS 0x006C4514 0x006C44D0>  # get_player_preview_info
+  mov       eax, <VERS 0x006BE37C 0x006C4514 0x006C44D0>  # get_player_preview_info
   jmp       eax
 preview_window_fix_end:
   # This patch applies in two places, so push the second set of args now, then
@@ -190,265 +190,266 @@ preview_window_fix_end:
 apply_static_patches:
   .include WriteCodeBlocks
   # These patches change various places where the character data size and slot count are referenced
-  .data    <VERS 0x00475294 0x004751A4>
+  .data    <VERS 0x00474E1C 0x00475294 0x004751A4>
   .data    0x00000001
   .binary  0C  # slot count; TDataProtocol::handle_E5
-  .data    <VERS 0x0047534B 0x0047525B>
+  .data    <VERS 0x00474ED3 0x0047534B 0x0047525B>
   .data    0x00000001
   .binary  0C  # slot count; import_player_preview
-  .data    <VERS 0x004786D1 0x004785E1>
+  .data    <VERS 0x00478259 0x004786D1 0x004785E1>
   .data    0x00000001
   .binary  0C  # slot count; TDataProtocol::handle_E4
-  .data    <VERS 0x00482559 0x0048242D>
+  .data    <VERS 0x0048208D 0x00482559 0x0048242D>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C17FB 0x006C17BF>
+  .data    <VERS 0x006BB693 0x006C17FB 0x006C17BF>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C1D07 0x006C1CCB>
+  .data    <VERS 0x006BBB77 0x006C1D07 0x006C1CCB>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C1D3A 0x006C1CFE>
+  .data    <VERS 0x006BBBAA 0x006C1D3A 0x006C1CFE>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C1D58 0x006C1D1C>
+  .data    <VERS 0x006BBBC8 0x006C1D58 0x006C1D1C>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C1E13 0x006C1DD7>
+  .data    <VERS 0x006BBC83 0x006C1E13 0x006C1DD7>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C226A 0x006C222E>
+  .data    <VERS 0x006BC0DA 0x006C226A 0x006C222E>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C22A9 0x006C226D>
+  .data    <VERS 0x006BC119 0x006C22A9 0x006C226D>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C22CA 0x006C228E>
+  .data    <VERS 0x006BC13A 0x006C22CA 0x006C228E>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C22DA 0x006C229E>
+  .data    <VERS 0x006BC14A 0x006C22DA 0x006C229E>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C2517 0x006C24DB>
+  .data    <VERS 0x006BC387 0x006C2517 0x006C24DB>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C267F 0x006C2643>
+  .data    <VERS 0x006BC4EF 0x006C267F 0x006C2643>
   .data    0x00000004
   .data    0x00022FBC  # save_count offset
-  .data    <VERS 0x006C2689 0x006C264D>
+  .data    <VERS 0x006BC4F9 0x006C2689 0x006C264D>
   .data    0x00000004
   .data    0x00022FBC  # save_count offset
-  .data    <VERS 0x006C272B 0x006C26EF>
+  .data    <VERS 0x006BC59B 0x006C272B 0x006C26EF>
   .data    0x00000004
   .data    0x00022FBC  # save_count offset
-  .data    <VERS 0x006C2741 0x006C2705>
+  .data    <VERS 0x006BC5B1 0x006C2741 0x006C2705>
   .data    0x00000004
   .data    0x00022FC0  # round2_seed offset
-  .data    <VERS 0x006C27CF 0x006C2793>
+  .data    <VERS 0x006BC63F 0x006C27CF 0x006C2793>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C28A8 0x006C286C>
+  .data    <VERS 0x006BC718 0x006C28A8 0x006C286C>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C314F 0x006C3113>
+  .data    <VERS 0x006BCFBE 0x006C314F 0x006C3113>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C357B 0x006C353F>
+  .data    <VERS 0x006BD3EB 0x006C357B 0x006C353F>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C35BA 0x006C357E>
+  .data    <VERS 0x006BD42A 0x006C35BA 0x006C357E>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C35E6 0x006C35AA>
+  .data    <VERS 0x006BD456 0x006C35E6 0x006C35AA>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C35F3 0x006C35B7>
+  .data    <VERS 0x006BD463 0x006C35F3 0x006C35B7>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C360E 0x006C35D2>
+  .data    <VERS 0x006BD47E 0x006C360E 0x006C35D2>
   .data    0x00000004
   .data    0x00022FBC  # save_count offset
-  .data    <VERS 0x006C3617 0x006C35DB>
+  .data    <VERS 0x006BD487 0x006C3617 0x006C35DB>
   .data    0x00000004
   .data    0x00022FBC  # save_count offset
-  .data    <VERS 0x006C371C 0x006C36E0>
+  .data    <VERS 0x006BD58C 0x006C371C 0x006C36E0>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C3B5A 0x006C3B1E>
+  .data    <VERS 0x006BD9CA 0x006C3B5A 0x006C3B1E>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C424D 0x006C4209>
+  .data    <VERS 0x006BE0B5 0x006C424D 0x006C4209>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C4833 0x006C47EF>
+  .data    <VERS 0x006BE69B 0x006C4833 0x006C47EF>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C486A 0x006C4826>
+  .data    <VERS 0x006BE6D2 0x006C486A 0x006C4826>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C49A6 0x006C4962>
+  .data    <VERS 0x006BE80E 0x006C49A6 0x006C4962>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C49DD 0x006C4999>
+  .data    <VERS 0x006BE845 0x006C49DD 0x006C4999>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C4AC5 0x006C4A81>
+  .data    <VERS 0x006BE92D 0x006C4AC5 0x006C4A81>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C4AFE 0x006C4ABA>
+  .data    <VERS 0x006BE966 0x006C4AFE 0x006C4ABA>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C4CDE 0x006C4C9A>
+  .data    <VERS 0x006BEB46 0x006C4CDE 0x006C4C9A>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C4D15 0x006C4CD1>
+  .data    <VERS 0x006BEB7D 0x006C4D15 0x006C4CD1>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C4DFD 0x006C4DB9>
+  .data    <VERS 0x006BEC65 0x006C4DFD 0x006C4DB9>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C4E36 0x006C4DF2>
+  .data    <VERS 0x006BEC9E 0x006C4E36 0x006C4DF2>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C4F9C 0x006C4F58>
+  .data    <VERS 0x006BEE04 0x006C4F9C 0x006C4F58>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C4FD7 0x006C4F94>
+  .data    <VERS 0x006BEE40 0x006C4FD7 0x006C4F94>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C51C5 0x006C5181>
+  .data    <VERS 0x006BF02D 0x006C51C5 0x006C5181>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C5201 0x006C51BD>
+  .data    <VERS 0x006BF069 0x006C5201 0x006C51BD>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C5376 0x006C5332>
+  .data    <VERS 0x006BF1DE 0x006C5376 0x006C5332>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C53B0 0x006C536C>
+  .data    <VERS 0x006BF218 0x006C53B0 0x006C536C>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C5545 0x006C5501>
+  .data    <VERS 0x006BF3AD 0x006C5545 0x006C5501>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C5581 0x006C553D>
+  .data    <VERS 0x006BF3E9 0x006C5581 0x006C553D>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C56F6 0x006C56B2>
+  .data    <VERS 0x006BF55E 0x006C56F6 0x006C56B2>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C5730 0x006C56EC>
+  .data    <VERS 0x006BF598 0x006C5730 0x006C56EC>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C58B6 0x006C5872>
+  .data    <VERS 0x006BF71E 0x006C58B6 0x006C5872>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C58F0 0x006C58AC>
+  .data    <VERS 0x006BF758 0x006C58F0 0x006C58AC>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C5A85 0x006C5A41>
+  .data    <VERS 0x006BF8ED 0x006C5A85 0x006C5A41>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C5AC1 0x006C5A7D>
+  .data    <VERS 0x006BF929 0x006C5AC1 0x006C5A7D>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C5BB2 0x006C5B6E>
+  .data    <VERS 0x006BFA1A 0x006C5BB2 0x006C5B6E>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C5BEC 0x006C5BA8>
+  .data    <VERS 0x006BFA54 0x006C5BEC 0x006C5BA8>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C5D72 0x006C5D2E>
+  .data    <VERS 0x006BFBDA 0x006C5D72 0x006C5D2E>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C5DAC 0x006C5D68>
+  .data    <VERS 0x006BFC14 0x006C5DAC 0x006C5D68>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C5F32 0x006C5EEE>
+  .data    <VERS 0x006BFD9A 0x006C5F32 0x006C5EEE>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C5F6C 0x006C5F28>
+  .data    <VERS 0x006BFDD4 0x006C5F6C 0x006C5F28>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C60F2 0x006C60AE>
+  .data    <VERS 0x006BFF5A 0x006C60F2 0x006C60AE>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C612C 0x006C60E8>
+  .data    <VERS 0x006BFF94 0x006C612C 0x006C60E8>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C6346 0x006C6303>
+  .data    <VERS 0x006C01AF 0x006C6346 0x006C6303>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C6381 0x006C633D>
+  .data    <VERS 0x006C01E9 0x006C6381 0x006C633D>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C6505 0x006C64C1>
+  .data    <VERS 0x006C036D 0x006C6505 0x006C64C1>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C6541 0x006C64FD>
+  .data    <VERS 0x006C03A9 0x006C6541 0x006C64FD>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C6632 0x006C65EE>
+  .data    <VERS 0x006C049A 0x006C6632 0x006C65EE>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C666C 0x006C6628>
+  .data    <VERS 0x006C04D4 0x006C666C 0x006C6628>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C67F2 0x006C67AE>
+  .data    <VERS 0x006C065A 0x006C67F2 0x006C67AE>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C682C 0x006C67E8>
+  .data    <VERS 0x006C0694 0x006C682C 0x006C67E8>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C69B2 0x006C696E>
+  .data    <VERS 0x006C081A 0x006C69B2 0x006C696E>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C69EC 0x006C69A8>
+  .data    <VERS 0x006C0854 0x006C69EC 0x006C69A8>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C6B87 0x006C6B43>
+  .data    <VERS 0x006C09EF 0x006C6B87 0x006C6B43>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C6BB8 0x006C6B74>
+  .data    <VERS 0x006C0A20 0x006C6BB8 0x006C6B74>
   .data    0x00000004
   .data    0x0000005D  # memcard block count
-  .data    <VERS 0x006C6C3A 0x006C6BF6>
+  .data    <VERS 0x006C0AA2 0x006C6C3A 0x006C6BF6>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C6C74 0x006C6C30>
+  .data    <VERS 0x006C0ADC 0x006C6C74 0x006C6C30>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C6E82 0x006C6E3E>
+  .data    <VERS 0x006C0CEA 0x006C6E82 0x006C6E3E>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C6EBC 0x006C6E78>
+  .data    <VERS 0x006C0D24 0x006C6EBC 0x006C6E78>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C70B9 0x006C7075>
+  .data    <VERS 0x006C0F21 0x006C70B9 0x006C7075>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C70F3 0x006C70AF>
+  .data    <VERS 0x006C0F5B 0x006C70F3 0x006C70AF>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C7A46 0x006C7A02>
+  .data    <VERS 0x006C18AE 0x006C7A46 0x006C7A02>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C7D66 0x006C7D22>
+  .data    <VERS 0x006C1BCE 0x006C7D66 0x006C7D22>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x006C7D7C 0x006C7D5E>
+  .data    <VERS 0x006C1C0A 0x006C7D7C 0x006C7D5E>
   .data    0x00000001
   .binary  0C  # slot count
-  .data    <VERS 0x006C7DC0 0x006C7D7C>
+  .data    <VERS 0x006C1C28 0x006C7DC0 0x006C7D7C>
   .data    0x00000004
   .data    0x00022FC4  # total file size
-  .data    <VERS 0x0077CC72 0x0077BE92>
+  .data    <VERS 0x00775BCE 0x0077CC72 0x0077BE92>
   .data    0x00000004
   .data    0x00022FB4  # bgm_test_songs_unlocked offset
 
   # Signature check on all save files (rewritten as loop)
-  .data    <VERS 0x006C1C69 0x006C1C2D>
+  .data    <VERS 0x006BBB04 0x006C1C69 0x006C1C2D> 
   .deltaof sig_check_begin, sig_check_end
+
 sig_check_begin:
   mov      edx, 0xC87ED5B1   # Expected signature value
   add      eax, 0x04E8       # &char_file_list->chars[0].part2.signature
@@ -469,10 +470,10 @@ sig_bad:
   inc      eax
   jmp      sig_check_end
   .binary  CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-sig_check_end:  # <VERS 006C1CB2 006C1C76>
+sig_check_end:  # <VERS 006BBB25 006C1CB2 006C1C76>
 
   # Send slot count in E3 command
-  .data    <VERS 0x0046EC10 0x0046EB20>  # TDataProtocol::send_E3_for_index
+  .data    <VERS 0x0046E798 0x0046EC10 0x0046EB20>  # TDataProtocol::send_E3_for_index
   .deltaof send_slot_count_in_E3_begin, send_slot_count_in_E3_end
 send_slot_count_in_E3_begin:
   # ecx = this (TDataProtocol*)
@@ -487,7 +488,7 @@ send_slot_count_in_E3_begin:
   mov      eax, [ecx]
   call     [eax + 0x20]  # this->send_command(&cmd, 0x10)  // ret 8
   add      esp, 8
-  mov      eax, <VERS 0x006C1ABC 0x006C1A80>
+  mov      eax, <VERS 0x006BB954 0x006C1ABC 0x006C1A80>
   call     eax  # set_current_char_slot(slot_index)  // ret 0
   add      esp, 8
   ret      4
@@ -515,7 +516,7 @@ show_slot_number_strend_again:
   jmp      show_slot_number_strend_again
 show_slot_number_strend_done:
   # Format the slot number and append it to the string
-  mov      ecx, [<VERS 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
+  mov      ecx, [<VERS 0x00A2EC50 0x00A38BD0 0x00A3B050>]  # scroll_bar = TAdScrollBarXb_objs[0]
   mov      ecx, [ecx + 0xAC]  # ecx = scroll_bar->selection_state[0].scroll_offset
   lea      ecx, [ecx + ebp + 1]
   push     ecx  # Slot number (scroll_offset + z)
@@ -523,7 +524,7 @@ show_slot_number_strend_done:
   .binary  20002800230025006400290020000000  # L" (#%d) "
 get_show_slot_number_suffix_fmt:
   push     eax  # Destination buffer
-  mov      eax, <VERS 0x00835578 0x00857E29>  # _swprintf
+  mov      eax, <VERS 0x0082C2F9 0x00835578 0x00857E29>  # _swprintf
   call     eax
   add      esp, 0x0C
   jmp      show_slot_number_end
@@ -541,11 +542,11 @@ update_existing_char_file_list:
   # patch is applied statically to the executable; this is only necessary when used as a server patch because the
   # character list is already allocated at the time the patch is applied.
   push      0x00022FC4  # total file size
-  mov       eax, <VERS 0x00835915 0x008581C5>  # operator_new
+  mov       eax, <VERS 0x0082C695 0x00835915 0x008581C5>  # operator_new
   call      eax
   add       esp, 4
-  mov       edx, [<VERS 0x00A939C4 0x00A95E44>]  # edx = old char_file_list
-  mov       [<VERS 0x00A939C4 0x00A95E44>], eax
+  mov       edx, [<VERS 0x00A89A04 0x00A939C4 0x00A95E44>]  # edx = old char_file_list
+  mov       [<VERS 0x00A89A04 0x00A939C4 0x00A95E44>], eax
   mov       ecx, [edx + 0xBA94]  # Copy bgm_test_songs_unlocked_high to new file
   mov       [eax + 0x00022FB4], ecx
   mov       ecx, [edx + 0xBA98]  # Copy bgm_test_songs_unlocked_low to new file
@@ -558,7 +559,7 @@ update_existing_char_file_list:
   add       edx, 4
   mov       ecx, 0xBA90
   call      memcpy  # Copy the existing 4 characters over
-  mov       eax, [<VERS 0x00A939C4 0x00A95E44>]
+  mov       eax, [<VERS 0x00A89A04 0x00A939C4 0x00A95E44>]
   add       eax, 0xBA94
   mov       ecx, 4
 clear_next_char:
@@ -578,19 +579,19 @@ clear_next_char_done:
   #   countof(char_file_list.chars) - 4,
   #   PSOCharacterFile::init,
   #   PSOCharacterFile::destroy)
-  push      <VERS 0x006C197C 0x006C1940>  # PSOCharacterFile::destroy
-  push      <VERS 0x006C182C 0x006C17F0>  # PSOCharacterFile::init
+  push      <VERS 0x006BB814 0x006C197C 0x006C1940>  # PSOCharacterFile::destroy
+  push      <VERS 0x006BB6C4 0x006C182C 0x006C17F0>  # PSOCharacterFile::init
   push      0x08  # slot count - 4
   push      0x2EA4  # sizeof(PSOCharacterFile)
-  mov       eax, [<VERS 0x00A939C4 0x00A95E44>]
+  mov       eax, [<VERS 0x00A89A04 0x00A939C4 0x00A95E44>]
   add       eax, 0xBA94
   push      eax
-  mov       eax, <VERS 0x00835E86 0x00858736>
+  mov       eax, <VERS 0x0082CC06 0x00835E86 0x00858736>
   call      eax
 
   # Fix the file's checksum
-  mov       eax, [<VERS 0x00A939C4 0x00A95E44>]
-  mov       ecx, <VERS 0x006C2738 0x006C26FC>
+  mov       eax, [<VERS 0x00A89A04 0x00A939C4 0x00A95E44>]
+  mov       ecx, <VERS 0x006BC5A8 0x006C2738 0x006C26FC>
   jmp       ecx  # PSOBBCharacterFileList::checksum(char_file_list)
 
 
@@ -605,10 +606,10 @@ update_existing_char_file_list_memcard:
   add       eax, 0x0000FFFF
   and       eax, 0xFFFFC000
   push      eax
-  mov       eax, <VERS 0x0084F258 0x0082E940>
+  mov       eax, <VERS 0x00845D80 0x0084F258 0x0082E940>
   call      eax  # malloc10(total file size)
   add       esp, 4
-  mov       [<VERS 0x00A939AC 0x00A95E2C>], eax
-  mov       edx, [<VERS 0x00A939C4 0x00A95E44>]
+  mov       [<VERS 0x00A899EC 0x00A939AC 0x00A95E2C>], eax
+  mov       edx, [<VERS 0x00A89A04 0x00A939C4 0x00A95E44>]
   mov       ecx, 0x00022FC4  # total file size
   jmp       memcpy

--- a/system/client-functions/BlueBurstExclusive/ServerEXPDisplay.s
+++ b/system/client-functions/BlueBurstExclusive/ServerEXPDisplay.s
@@ -5,7 +5,7 @@
 .meta name="Server EXP display"
 .meta description=""
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
@@ -20,7 +20,7 @@ start:
 install_hook:
   pop       ecx
   push      0  # Write address instead of a call/jmp opcode
-  push      <VERS 0x00A0DC54 0x00A0FC54>
+  push      <VERS 0x00A03CB4 0x00A0DC54 0x00A0FC54>
   call      get_code_size
   .deltaof  handle_6xBF_start, handle_6xBF_end
 get_code_size:
@@ -30,7 +30,7 @@ get_code_size:
 handle_6xBF_start:  # [std](G_6xBF* cmd @ [esp + 4]) -> void
   mov       edx, [esp + 4]
 
-  mov       ecx, [<VERS 0x00A9A074 0x00A9C4F4>]  # local_client_id
+  mov       ecx, [<VERS 0x00A90034 0x00A9A074 0x00A9C4F4>]  # local_client_id
   cmp       [edx + 2], cx
   jne       skip_text
 
@@ -47,25 +47,25 @@ handle_6xBF_start:  # [std](G_6xBF* cmd @ [esp + 4]) -> void
   jnz       enemy_entity_ok
 
   # Use player entity if enemy entity is already gone
-  mov       eax, <VERS 0x0068D618 0x0068D5AC>
+  mov       eax, <VERS 0x00687EDC 0x0068D618 0x0068D5AC>
   xchg      eax, ecx
   call      ecx  # eax = TObjPlayer::for_client_id(local_client_id); conveniently, this function preserves all regs except eax
 
 enemy_entity_ok:
   push      0x0000FFFF  # entity_id; ignored by TFontSmallTask if not a player
   push      dword [edx + 4]  # amount = cmd.amount
-  push      <VERS 0x00976380 0x009783A0>  # prefix = L"EXP"
+  push      <VERS 0x0096BCC0 0x00976380 0x009783A0>  # prefix = L"EXP"
   push      0x14
   push      0x14
   push      0xFFFF00FF  # color (ARGB)
   add       eax, 0x300
   push      eax  # position
-  mov       eax, <VERS 0x0078B8E8 0x0078AABC>
+  mov       eax, <VERS 0x0078460C 0x0078B8E8 0x0078AABC>
   call      eax  # TFontSmallTask___new__(...)
   add       esp, 0x1C
 
 skip_text:
-  mov       eax, <VERS 0x0069292C 0x006928C0>  # Original handle_6xBF
+  mov       eax, <VERS 0x0068D194 0x0069292C 0x006928C0>  # Original handle_6xBF
   jmp       eax  # original_handle_6xBF(cmd)
 
 get_enemy_entity:
@@ -81,7 +81,7 @@ handle_6xBF_end:
 apply_static_patches:
   .include  WriteCodeBlocks
 
-  .data     <VERS 0x0078827D 0x0078749D>
+  .data     <VERS 0x00780FA1 0x0078827D 0x0078749D>
   .deltaof  disable_kill_enemy_callsite_start, disable_kill_enemy_callsite_end
 disable_kill_enemy_callsite_start:
   nop
@@ -91,7 +91,7 @@ disable_kill_enemy_callsite_start:
   nop
 disable_kill_enemy_callsite_end:
 
-  .data     <VERS 0x00777381 0x007765A5>
+  .data     <VERS 0x007702DD 0x00777381 0x007765A5>
   .deltaof  disable_exp_steal_callsite_start, disable_exp_steal_callsite_end
 disable_exp_steal_callsite_start:
   add       esp, 0x0C  # Original function has `ret 0x0C`

--- a/system/client-functions/BlueBurstExclusive/StackLimits.s
+++ b/system/client-functions/BlueBurstExclusive/StackLimits.s
@@ -7,7 +7,7 @@
 .meta name="Item stacks"
 .meta description=""
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
@@ -16,7 +16,7 @@ start:
   .include  WriteCodeBlocks
 
   # Patch 1: rewrite item_is_stackable
-  .data     <VERS 0x005C5020 0x005C502C>
+  .data     <VERS 0x005C3DD8 0x005C5020 0x005C502C>
   .deltaof  item_is_stackable_start, item_is_stackable_end
 
 item_is_stackable_start:
@@ -31,7 +31,7 @@ item_is_stackable_start:
   push      eax
   mov       ecx, esp
 
-  .binary   <VERS E8D8130100 E8EC130100>  # call max_stack_size_for_tool_start
+  .binary   <VERS E85C090100 E8D8130100 E8EC130100>  # call max_stack_size_for_tool_start
   pop       ecx
   cmp       eax, 1
   jg        return_1
@@ -47,7 +47,7 @@ return_1:
 item_is_stackable_end:
 
   # Patch 2: rewrite max_stack_size_for_tool
-  .data     <VERS 0x005D6410 0x005D6430>
+  .data     <VERS 0x005D474C 0x005D6410 0x005D6430>
   .deltaof  max_stack_size_for_tool_start, max_stack_size_for_tool_end
 
 max_stack_size_for_tool_start:

--- a/system/client-functions/CallProtectedHandler.s
+++ b/system/client-functions/CallProtectedHandler.s
@@ -77,7 +77,7 @@ get_data_addr:
 
 
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 start:
   jmp    get_data_addr
@@ -103,8 +103,8 @@ resume:
 get_data_addr:
   call   resume
 
-  .data  <VERS 0x00AAC870 0x00AAECF0>  # should_allow_protected_commands
-  .data  <VERS 0x008015D0 0x00800860>  # RcvPsoData2[std](void* data @ [esp + 4], uint32_t size @ [esp + 8])
+  .data  <VERS 0x00AA2830 0x00AAC870 0x00AAECF0>  # should_allow_protected_commands
+  .data  <VERS 0x007F95E0 0x008015D0 0x00800860>  # RcvPsoData2[std](void* data @ [esp + 4], uint32_t size @ [esp + 8])
 
 
 

--- a/system/client-functions/DisableIdleDisconnect.s
+++ b/system/client-functions/DisableIdleDisconnect.s
@@ -34,8 +34,8 @@ start:
 
 
 
-  .versions 59NJ 59NL
-  .data     <VERS 0x007A1233 0x007A03F7>
+  .versions 50YJ 59NJ 59NL
+  .data     <VERS 0x00799D0B 0x007A1233 0x007A03F7>
   .data     0x00000005
   mov       eax, 0
 

--- a/system/client-functions/DrawDistance.s
+++ b/system/client-functions/DrawDistance.s
@@ -228,21 +228,21 @@ p5_3e:
 
 
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 write_call_func:
   .include  WriteCallToCode
 
 start:
   mov       eax, 0x41800000        # Environment clip distance mod 16.0f
-  mov       [<VERS 0x0097D198 0x0097F1B8>], eax      # This affects mostly static map objects
-  mov       [<VERS 0x0097D19C 0x0097F1BC>], eax
-  mov       [<VERS 0x0097D1A0 0x0097F1C0>], eax
+  mov       [<VERS 0x00972AF8 0x0097D198 0x0097F1B8>], eax      # This affects mostly static map objects
+  mov       [<VERS 0x00972AFC 0x0097D19C 0x0097F1BC>], eax
+  mov       [<VERS 0x00972B00 0x0097D1A0 0x0097F1C0>], eax
 
   mov       ax, 0x9090
-  mov       [<VERS 0x00689BC7 0x00689B5B>], ax       # Players draw distance 10000.0f always
+  mov       [<VERS 0x0068476F 0x00689BC7 0x00689B5B>], ax       # Players draw distance 10000.0f always
   mov       eax, 0x41000000                          # Use newly acquired skipped branch room
-  mov       [<VERS 0x00689BD1 0x00689B65>], eax      # to store our float multiplier
+  mov       [<VERS 0x00684779 0x00689BD1 0x00689B65>], eax      # to store our float multiplier
 
   call      patch_func_1           # Floor items
   call      patch_func_2           # Whole bunch of stuff, including NPCs
@@ -256,7 +256,7 @@ start:
 patch_func_1:
   pop       ecx
   push      8
-  push      <VERS 0x005C525B 0x005C5267>
+  push      <VERS 0x005C4013 0x005C525B 0x005C5267>
   call      get_code_size1
   .deltaof  patch_code1, patch_code_end1
 get_code_size1:
@@ -265,7 +265,7 @@ get_code_size1:
   call      patch_code_end1
 patch_code1:
   mov       edx, [esp + 0x18]
-  fld       st0, dword [<VERS 0x00689BD1 0x00689B65>]
+  fld       st0, dword [<VERS 0x00684779 0x00689BD1 0x00689B65>]
   fld       st0, dword [esp + 0x14]
   fmulp     st1, st0
   ret
@@ -277,7 +277,7 @@ patch_code_end1:
 patch_func_2:
   pop       ecx
   push      9
-  push      <VERS 0x007BB21E 0x007BA472>
+  push      <VERS 0x07B3396 0x007BB21E 0x007BA472>
   call      get_code_size2
   .deltaof  patch_code2, patch_code_end2
 get_code_size2:
@@ -286,7 +286,7 @@ get_code_size2:
   call      patch_code_end2
 patch_code2:
   test      eax, 0x400
-  fld       st0, dword [<VERS 0x00689BD1 0x00689B65>]
+  fld       st0, dword [<VERS 0x00684779 0x00689BD1 0x00689B65>]
   fld       st0, dword [esp + 0x2C]
   fmulp     st1, st0
   ret
@@ -296,18 +296,18 @@ patch_code_end2:
 
 # Duplicate function from above, reuse same hook
 patch_func_3:
-  mov       eax, dword [<VERS 0x007BB21F 0x007BA473>]
+  mov       eax, dword [<VERS 0x007B3397 0x007BB21F 0x007BA473>]
   add       eax, 0x002A1C74
-  mov       dword [<VERS 0x00518843 0x005187FF>], eax
-  mov       byte [<VERS 0x00518842 0x005187FE>], 0xE8
-  mov       dword [<VERS 0x00518847 0x00518803>], 0x90909090
+  mov       dword [<VERS 0x005179BF 0x00518843 0x005187FF>], eax
+  mov       byte [<VERS 0x005179BE 0x00518842 0x005187FE>], 0xE8
+  mov       dword [<VERS 0x005179C3 0x00518847 0x00518803>], 0x90909090
   ret
 
 # TOComputerMachine01
 patch_func_4:
   pop       ecx
   push      7
-  push      <VERS 0x00616FF4 0x00616FFC>
+  push      <VERS 0x00611E30 0x00616FF4 0x00616FFC>
   call      get_code_size4
   .deltaof  patch_code4, patch_code_end4
 get_code_size4:
@@ -316,7 +316,7 @@ get_code_size4:
   call      patch_code_end4
 patch_code4:
   lea       edx, [edi + 0x38]
-  fld       st0, dword [<VERS 0x00689BD1 0x00689B65>]
+  fld       st0, dword [<VERS 0x00684779 0x00689BD1 0x00689B65>]
   fld       st0, dword [esp + 0x14]
   fmulp     st1, st0
   ret
@@ -328,7 +328,7 @@ patch_code_end4:
 patch_func_5:
   pop       ecx
   push      6
-  push      <VERS 0x006439A8 0x0064394C>
+  push      <VERS 0x0063E6E4 0x006439A8 0x0064394C>
   call      get_code_size5
   .deltaof  patch_code5, patch_code_end5
 get_code_size5:
@@ -336,7 +336,7 @@ get_code_size5:
   push      dword [eax]
   call      patch_code_end5
 patch_code5:
-  fld       st0, dword [<VERS 0x00689BD1 0x00689B65>]
+  fld       st0, dword [<VERS 0x00684779 0x00689BD1 0x00689B65>]
   fld       st0, dword [esp + 0x28]
   fmulp     st1, st0
   fchs      st0
@@ -349,7 +349,7 @@ patch_code_end5:
 patch_func_6:
   pop       ecx
   push      6
-  push      <VERS 0x0065B959 0x0065B985>
+  push      <VERS 0x00656501 0x0065B959 0x0065B985>
   call      get_code_size6
   .deltaof  patch_code6, patch_code_end6
 get_code_size6:
@@ -358,7 +358,7 @@ get_code_size6:
   call      patch_code_end6
 patch_code6:
   mov       ebp, ecx
-  fld       st0, dword [<VERS 0x00689BD1 0x00689B65>]
+  fld       st0, dword [<VERS 0x00684779 0x00689BD1 0x00689B65>]
   fld       st0, dword [esp + 0x30]
   fmulp     st1, st0
   ret

--- a/system/client-functions/EnemyDamageSyncBB.s
+++ b/system/client-functions/EnemyDamageSyncBB.s
@@ -4,7 +4,7 @@
 .meta description="Mitigates effects\nof enemy health\ndesync"
 .meta client_flag="0x0000001000000000"
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
@@ -18,8 +18,8 @@ write_address_of_code:
 start:
 
   # Replace 6x09 with 6xE4 in subcommand handler table
-  mov       dword [<VERS 0x00A0DC30 0x00A0FC30>], 0x000600E4  # subcommand=0xE4, flags=6
-  push      <VERS 0x00A0DC34 0x00A0FC34>
+  mov       dword [<VERS 0x00A03C90 0x00A0DC30 0x00A0FC30>], 0x000600E4  # subcommand=0xE4, flags=6
+  push      <VERS 0x00A03C94 0x00A0DC34 0x00A0FC34>
   call      +4
   .deltaof  handle_6xE4_start, handle_6xE4_end
   pop       eax
@@ -31,7 +31,7 @@ handle_6xE4_start:  # (G_6xE4* cmd @ [esp + 4]) -> void
   push      esi
   push      edi
 
-  test      byte [<VERS 0x00AA8DFC 0x00AAB27C>], 0x80
+  test      byte [<VERS 0x00A9EDBC 0x00AA8DFC 0x00AAB27C>], 0x80 #0x2480
   jz        handle_6xE4_return
   mov       ebx, [esp + 0x10]  # cmd
   movzx     eax, word [ebx + 2]
@@ -47,7 +47,7 @@ handle_6xE4_start:  # (G_6xE4* cmd @ [esp + 4]) -> void
   movzx     eax, word [ebx + 2]
   and       eax, 0x0FFF
   imul      eax, eax, 0x0C
-  add       eax, [<VERS 0x00AADE38 0x00AB02B8>]  # eax = state_for_enemy(cmd->header.entity_id)
+  add       eax, [<VERS 0x00AA3DF8 0x00AADE38 0x00AB02B8>]  # eax = state_for_enemy(cmd->header.entity_id)
 
   cmp       dword [ebx + 0x0C], 0
   jl        handle_6xE4_not_proportional
@@ -94,7 +94,7 @@ handle_6xE4_not_proportional:
   mov       [esp + 4], si  # out_cmd.entity_index
   mov       [esp + 6], di  # out_cmd.total_damage
   mov       ecx, esp
-  mov       edx, <VERS 0x00801150 0x008003E0>
+  mov       edx, <VERS 0x007F9160 0x00801150 0x008003E0>
   call      edx  # send_and_handle_60(&out_cmd);
   add       esp, 0x10
   jmp       handle_6xE4_return
@@ -130,41 +130,41 @@ handle_6xE4_end:
   # Note: in 59NJ this object is TObjectV00b421c0 (it's the same as 3OE1's TObjectV8047c128)
   # Write TObjectV00b441c0::incr_hp_with_sync
   push      5
-  push      <VERS 0x00775224 0x00774448>  # TObjectV00b441c0::v18_accept_hit (presumably Resta) - this is add_hp, not subtract_hp!
+  push      <VERS 0x0076E17C 0x00775224 0x00774448>  # TObjectV00b441c0::v18_accept_hit (presumably Resta) - this is add_hp, not subtract_hp!
   push      5
-  push      <VERS 0x00778063 0x00777287>  # TObjectV00b441c0::subtract_hp_if_not_in_state_2
+  push      <VERS 0x00770FBF 0x00778063 0x00777287>  # TObjectV00b441c0::subtract_hp_if_not_in_state_2
   push      5
-  push      <VERS 0x00777AB2 0x00776CD6>  # TObjectV00b441c0::v19_handle_hit_special_effects
+  push      <VERS 0x007709DD 0x00777AB2 0x00776CD6>  # TObjectV00b441c0::v19_handle_hit_special_effects
   push      5
-  push      <VERS 0x00777B2B 0x00776D4F>  # TObjectV00b441c0::v19_handle_hit_special_effects
+  push      <VERS 0x00770A56 0x00777B2B 0x00776D4F>  # TObjectV00b441c0::v19_handle_hit_special_effects
   push      5
-  push      <VERS 0x00777BFC 0x00776E20>  # TObjectV00b441c0::v19_handle_hit_special_effects
+  push      <VERS 0x00770B27 0x00777BFC 0x00776E20>  # TObjectV00b441c0::v19_handle_hit_special_effects
   push      5
-  push      <VERS 0x00777C75 0x00776E99>  # TObjectV00b441c0::v19_handle_hit_special_effects
+  push      <VERS 0x00770BA0 0x00777C75 0x00776E99>  # TObjectV00b441c0::v19_handle_hit_special_effects
   push      5
-  push      <VERS 0x00776D2D 0x00775F51>  # TObjectV00b441c0::v19_handle_hit_special_effects
+  push      <VERS 0x0076FC85 0x00776D2D 0x00775F51>  # TObjectV00b441c0::v19_handle_hit_special_effects
   push      5
-  push      <VERS 0x007769C2 0x00775BE6>  # TObjectV00b441c0::v19_handle_hit_special_effects
+  push      <VERS 0x0076F91A 0x007769C2 0x00775BE6>  # TObjectV00b441c0::v19_handle_hit_special_effects
   push      5
-  push      <VERS 0x0077683C 0x00775A60>  # TObjectV00b441c0::v19_handle_hit_special_effects
+  push      <VERS 0x0076F794 0x0077683C 0x00775A60>  # TObjectV00b441c0::v19_handle_hit_special_effects
   push      5
-  push      <VERS 0x00776502 0x00775726>  # TObjectV00b441c0::v19_handle_hit_special_effects (Devil's/Demon's)
+  push      <VERS 0x0076F45A 0x00776502 0x00775726>  # TObjectV00b441c0::v19_handle_hit_special_effects (Devil's/Demon's)
   push      5
-  push      <VERS 0x00775B57 0x00774D7B>  # TObjectV00b441c0::v18_accept_hit
+  push      <VERS 0x0076EAB9 0x00775B57 0x00774D7B>  # TObjectV00b441c0::v18_accept_hit
   push      5
-  push      <VERS 0x00775A23 0x00774C47>  # TObjectV00b441c0::v18_accept_hit
+  push      <VERS 0x0076E985 0x00775A23 0x00774C47>  # TObjectV00b441c0::v18_accept_hit
   push      5
-  push      <VERS 0x007757F0 0x00774A14>  # TObjectV00b441c0::v18_accept_hit
+  push      <VERS 0x0076E752 0x007757F0 0x00774A14>  # TObjectV00b441c0::v18_accept_hit
   push      5
-  push      <VERS 0x00775606 0x0077482A>  # TObjectV00b441c0::v18_accept_hit
+  push      <VERS 0x0076E568 0x00775606 0x0077482A>  # TObjectV00b441c0::v18_accept_hit
   push      5
-  push      <VERS 0x007754BC 0x007746E0>  # TObjectV00b441c0::v18_accept_hit
+  push      <VERS 0x0076E41E 0x007754BC 0x007746E0>  # TObjectV00b441c0::v18_accept_hit
   push      5
-  push      <VERS 0x00774E3D 0x00774061>  # TObjectV00b441c0::v18_accept_hit
+  push      <VERS 0x0076DD95 0x00774E3D 0x00774061>  # TObjectV00b441c0::v18_accept_hit
   push      5
-  push      <VERS 0x00774CD6 0x00773EFA>  # TObjectV00b441c0::v18_accept_hit
+  push      <VERS 0x0076DC2E 0x00774CD6 0x00773EFA>  # TObjectV00b441c0::v18_accept_hit
   push      5
-  push      <VERS 0x00774713 0x00773937>  # TObjectV00b441c0::v17
+  push      <VERS 0x0076D675 0x00774713 0x00773937>  # TObjectV00b441c0::v17
   push      18
   call      +4
   .deltaof  on_add_or_subtract_hp_start, on_add_or_subtract_hp_end
@@ -173,7 +173,7 @@ handle_6xE4_end:
   call      on_add_or_subtract_hp_end
 
 on_add_or_subtract_hp_start:  # (TObjectV00b441c0* this @ ecx, int16_t amount @ [esp + 4]) -> bool @ eax
-  test      byte [<VERS 0x00AA8DFC 0x00AAB27C>], 0x80
+  test      byte [<VERS 0x00A9EDBC 0x00AA8DFC 0x00AAB27C>], 0x80
   jz        on_add_or_subtract_hp_skip_send
   movzx     eax, word [ecx + 0x1C]  # ene->entity_id
   cmp       eax, 0x1000
@@ -183,14 +183,14 @@ on_add_or_subtract_hp_start:  # (TObjectV00b441c0* this @ ecx, int16_t amount @ 
 
   and       eax, 0x0FFF
   imul      eax, eax, 0x0C
-  add       eax, [<VERS 0x00AADE38 0x00AB02B8>]  # eax = state_for_enemy(cmd->header.entity_id)
+  add       eax, [<VERS 0x00AA3DF8 0x00AADE38 0x00AB02B8>]  # eax = state_for_enemy(cmd->header.entity_id)
 
   sub       esp, 0x10
   mov       word [esp], 0x04E4
   mov       dx, [ecx + 0x1C]
   mov       [esp + 0x02], dx  # cmd.entity_id
   mov       dx, [esp + 0x14]
-  cmp       dword [esp + 0x10], <VERS 0x00775229 0x0077444D>  # Check if callsite is add_hp
+  cmp       dword [esp + 0x10], <VERS 0x0076E181 0x00775229 0x0077444D>  # Check if callsite is add_hp
   jne       on_add_or_subtract_hp_skip_negate_amount
   neg       dx
 on_add_or_subtract_hp_skip_negate_amount:
@@ -203,7 +203,7 @@ on_add_or_subtract_hp_skip_negate_amount:
   mov       [esp + 0x0A], dx  # cmd.max_hp
   mov       dword [esp + 0x0C], 0xBF800000  # cmd.factor
 
-  cmp       dword [esp + 0x10], <VERS 0x00776507 0x0077572B>  # Check if callsite is Devil's/Demon's
+  cmp       dword [esp + 0x10], <VERS 0x0076F45F 0x00776507 0x0077572B>  # Check if callsite is Devil's/Demon's
   jne       on_add_or_subtract_hp_not_proportional
   # esp is 0x18 down from where it is in caller's context
   mov       edx, 100
@@ -221,16 +221,16 @@ on_add_or_subtract_hp_not_proportional:
   push      ecx
   push      0x10
   push      edx
-  mov       ecx, [<VERS 0x00AA8E04 0x00AAB284>]
-  mov       edx, <VERS 0x007D4CBC 0x007D3F38>
+  mov       ecx, [<VERS 0x00A9EDC4 0x00AA8E04 0x00AAB284>]
+  mov       edx, <VERS 0x007CCCCC 0x007D4CBC 0x007D3F38>
   call      edx  # send_60(root_protocol, &cmd, sizeof(cmd));
   pop       ecx
   add       esp, 0x10
 
 on_add_or_subtract_hp_skip_send:
-  mov       eax, <VERS 0x007781F0 0x00777414>  # subtract_hp
-  mov       edx, <VERS 0x007781B0 0x007773D4>  # add_hp
-  cmp       dword [esp], <VERS 0x00775229 0x0077444D>  # Check if callsite is add_hp
+  mov       eax, <VERS 0x0077114C 0x007781F0 0x00777414>  # subtract_hp
+  mov       edx, <VERS 0x0077110C 0x007781B0 0x007773D4>  # add_hp
+  cmp       dword [esp], <VERS 0x0076E181 0x00775229 0x0077444D>  # Check if callsite is add_hp
   cmove     eax, edx
   jmp       eax
 
@@ -240,7 +240,7 @@ on_add_or_subtract_hp_end:
 
 
   push      5
-  push      <VERS 0x0078864B 0x0078781F>
+  push      <VERS 0x0078136F 0x0078864B 0x0078781F>
   push      1
   call      +4
   .deltaof  on_6x0A_patch_start, on_6x0A_patch_end
@@ -249,7 +249,7 @@ on_add_or_subtract_hp_end:
   call      on_6x0A_patch_end
 
 on_6x0A_patch_start:  # (TObjectV00b441c0* this @ ecx, int16_t amount @ [esp + 4]) -> bool @ eax
-  test      byte [<VERS 0x00AA8DFC 0x00AAB27C>], 0x80
+  test      byte [<VERS 0x00A9EDBC 0x00AA8DFC 0x00AAB27C>], 0x80
   jz        on_6x0A_patch_skip_write
   mov       [esp + 0x0A], cx
 on_6x0A_patch_skip_write:

--- a/system/client-functions/EnemyHPBarsBB.s
+++ b/system/client-functions/EnemyHPBarsBB.s
@@ -3,47 +3,47 @@
 .meta name="Enemy HP bars"
 .meta description="Shows HP bars in\nenemy info windows"
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
   .offsetof start
 start:
   .include  WriteCodeBlocks
-  .data     <VERS 0x0073197D 0x007318DD>
+  .data     <VERS 0x0072B141 0x0073197D 0x007318DD>
   .data     6
   .binary   81E2FDFFFFFF
-  .data     <VERS 0x00731FCF 0x00731F2F>
+  .data     <VERS 0x0072B793 0x00731FCF 0x00731F2F>
   .data     1
   .binary   FA
-  .data     <VERS 0x009F0DA4 0x009F2DA4>
+  .data     <VERS 0x009E6D84 0x009F0DA4 0x009F2DA4>
   .data     4
   .data     0x42480000
-  .data     <VERS 0x009F0DAC 0x009F2DAC>
+  .data     <VERS 0x009E6D8C 0x009F0DAC 0x009F2DAC>
   .data     4
   .data     0x41C00000
-  .data     <VERS 0x009F0DD4 0x009F2DD4>
+  .data     <VERS 0x009E6DB4 0x009F0DD4 0x009F2DD4>
   .data     4
   .data     0x42480000
-  .data     <VERS 0x009F0DDC 0x009F2DDC>
+  .data     <VERS 0x009E6DBC 0x009F0DDC 0x009F2DDC>
   .data     4
   .data     0x41C00000
-  .data     <VERS 0x009F0E04 0x009F2E04>
+  .data     <VERS 0x009E6DE4 0x009F0E04 0x009F2E04>
   .data     4
   .data     0x42480000
-  .data     <VERS 0x009F0E0C 0x009F2E0C>
+  .data     <VERS 0x009E6DEC 0x009F0E0C 0x009F2E0C>
   .data     4
   .data     0x41C00000
-  .data     <VERS 0x009F0E34 0x009F2E34>
+  .data     <VERS 0x009E6E14 0x009F0E34 0x009F2E34>
   .data     4
   .data     0x42480000
-  .data     <VERS 0x009F0E3C 0x009F2E3C>
+  .data     <VERS 0x009E6E1C 0x009F0E3C 0x009F2E3C>
   .data     4
   .data     0x41C00000
-  .data     <VERS 0x009F0E64 0x009F2E64>
+  .data     <VERS 0x009E6E44 0x009F0E64 0x009F2E64>
   .data     4
   .data     0x42200000
-  .data     <VERS 0x009F0E80 0x009F2E80>
+  .data     <VERS 0x009E6E60 0x009F0E80 0x009F2E80>
   .data     4
   .data     0xFF00FF15
   .data     0x00000000

--- a/system/client-functions/ExitAnywhere.s
+++ b/system/client-functions/ExitAnywhere.s
@@ -52,11 +52,11 @@ start:
 
 
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 start:
   xor    eax, eax
-  mov    [<VERS 0x00A931A4 0x00A95624>], eax  # is_in_quest = false
-  mov    [<VERS 0x00A93160 0x00A955E0>], eax  # dat_source_type = NONE
+  mov    [<VERS 0x00A89164 0x00A931A4 0x00A95624>], eax  # is_in_quest = false
+  mov    [<VERS 0x00A89120 0x00A93160 0x00A955E0>], eax  # dat_source_type = NONE
   inc    eax
-  mov    [<VERS 0x00AAC254 0x00AAE6D4>], ax  # should_leave_game = true
+  mov    [<VERS 0x00AA2214 0x00AAC254 0x00AAE6D4>], ax  # should_leave_game = true
   ret

--- a/system/client-functions/FastTekker.s
+++ b/system/client-functions/FastTekker.s
@@ -64,15 +64,15 @@ patch2_end:
 
 
 
-  .versions 59NJ 59NL
+  .versions 50YJ 59NJ 59NL
 
-  .data     <VERS 0x006DA14B 0x006DA113>
+  .data     <VERS 0x006D3F7B 0x006DA14B 0x006DA113>
   .deltaof  patch1_start, patch1_end
 patch1_start:
   mov       dword [edi + 0x14C], 1
 patch1_end:
 
-  .data     <VERS 0x006DA168 0x006DA130>
+  .data     <VERS 0x006D3F98 0x006DA168 0x006DA130>
   .deltaof  patch2_start, patch2_end
 patch2_start:
   nop

--- a/system/client-functions/HungryMagSound.s
+++ b/system/client-functions/HungryMagSound.s
@@ -122,12 +122,12 @@ hook6_end:
 
 
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 start:
   pop       ecx
   push      6
-  push      <VERS 0x005D91BE 0x005D91E2>
+  push      <VERS 0x005D72EA 0x005D91BE 0x005D91E2>
   call      get_code_size
   .deltaof  patch_code, patch_code_end
 get_code_size:
@@ -135,16 +135,16 @@ get_code_size:
   push      dword [eax]
   call      patch_code_end
 patch_code:  # [eax] (TItemMag* this @ ecx) -> void
-  mov       dword [ecx + 0x01B8], eax
+  mov       dword [ecx + <VERS 0x01B4 0x01B8 0x01B8>], eax
   mov       eax, [ecx + 0x00F8]
   movzx     eax, word [eax + 0x001C]  # eax = this->owner_player->entity_id
-  cmp       [<VERS 0x00A9A074 0x00A9C4F4>], eax
+  cmp       [<VERS 0x00A90034 0x00A9A074 0x00A9C4F4>], eax
   jne       patch_code_skip_sound
   push      0
   push      0
   push      0
   push      0xAC
-  mov       eax, <VERS 0x00815020 0x00814298>
+  mov       eax, <VERS 0x0080CAB4 0x00815020 0x00814298>
   call      eax
   add       esp, 0x10
 patch_code_skip_sound:

--- a/system/client-functions/NoRareSelling.s
+++ b/system/client-functions/NoRareSelling.s
@@ -88,22 +88,22 @@ tool_check_end:
 
 
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 start:
   # This works by setting the item price to zero if it's rare, which causes the game to prevent you from selling the
   # item. For armors and weapons, this is easy because there are easily-patchable opcodes within branches that return a
   # constant price for rare items.
   xor       eax, eax
-  mov       [<VERS 0x005D258F 0x005D25AF>], eax      # Rare armors
-  mov       [<VERS 0x005D26D1 0x005D26F1>], eax      # Unidentified weapons
-  mov       [<VERS 0x005D26E6 0x005D2706>], eax      # Rare weapons
+  mov       [<VERS 0x005D12D7 0x005D258F 0x005D25AF>], eax      # Rare armors
+  mov       [<VERS 0x005D1419 0x005D26D1 0x005D26F1>], eax      # Unidentified weapons
+  mov       [<VERS 0x005D142E 0x005D26E6 0x005D2706>], eax      # Rare weapons
 
   # For tools, it's harder to implement this, because the price comes from the ItemPMT tools table and there is no
   # branch for rares. Still, we can add a branch to a stub to handle tools.
   pop       ecx
   push      5
-  push      <VERS 0x005D2508 0x005D2528>
+  push      <VERS 0x005D1250 0x005D2508 0x005D2528>
   call      get_code_size
   .deltaof  patch_code, patch_code_end
 get_code_size:
@@ -113,7 +113,7 @@ get_code_size:
 patch_code:
   # TODO: It'd be nice to have something like WriteJumpToAndFromCode, since this hook is supposed to return to a
   # different place than where it was called, hence this mov [esp].
-  mov       dword [esp], <VERS 0x005D2556 0x005D2576>
+  mov       dword [esp], <VERS 0x005D129E 0x005D2556 0x005D2576>
   xor       edi, edi
   test      byte [eax + 0x14], 0x80  # flags & 0x80 = is rare
   cmovz     edi, [eax + 0x10]  # Use price from table if not rare

--- a/system/client-functions/PaletteBB.s
+++ b/system/client-functions/PaletteBB.s
@@ -6,7 +6,7 @@
 .meta name="Palette"
 .meta description="Enables the alternate action\npalette for number keys"
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 entry_ptr:
 reloc0:
@@ -17,10 +17,10 @@ write_call_func:
 
 start:
   mov       al, 0xEB
-  mov       [<VERS 0x0068A7A5 0x0068A739>], al                  # SecondaryPaletteAttack1
+  mov       [<VERS 0x0068515D 0x0068A7A5 0x0068A739>], al                  # SecondaryPaletteAttack1
   xor       al, al
-  mov       [<VERS 0x006A11B7 0x006A114F>], al                  # SecondaryPaletteAttack2
-  mov       [<VERS 0x006A0CB7 0x006A0C4F>], al                  # SecondaryPaletteAttack3
+  mov       [<VERS 0x0069B53B 0x006A11B7 0x006A114F>], al                  # SecondaryPaletteAttack2
+  mov       [<VERS 0x0069B047 0x006A0CB7 0x006A0C4F>], al                  # SecondaryPaletteAttack3
 
   call      patch_func_1                      # GetCurrentPalette
   call      patch_func_2                      # CheckHotkey1_1
@@ -35,7 +35,7 @@ start:
 patch_func_1:
   pop       ecx
   push      8
-  push      <VERS 0x00748990 0x00748944>
+  push      <VERS 0x0074196B 0x00748990 0x00748944>
   call      get_code_size1
   .deltaof  patch_code1, patch_code_end1
 get_code_size1:
@@ -47,7 +47,7 @@ patch_code1:
   mov       edx, [edx + 0x2C]
   movzx     edx, byte [edx + 0x62]
   test      edx, edx
-  setnz     byte [<VERS 0x00748B1B 0x00748ACF>]
+  setnz     byte [<VERS 0x00741B59 0x00748B1B 0x00748ACF>]
   mov       edx, edi
   and       edx, 0xFF
   ret
@@ -59,7 +59,7 @@ patch_code_end1:
 patch_func_2:
   pop       ecx
   push      5
-  push      <VERS 0x007489DE 0x00748992>
+  push      <VERS 0x007419B9 0x007489DE 0x00748992>
   call      get_code_size2
   .deltaof  patch_code2, patch_code_end2
 get_code_size2:
@@ -67,7 +67,7 @@ get_code_size2:
   push      dword [eax]
   call      patch_code_end2
 patch_code2:
-  cmp       byte [<VERS 0x00748B1B 0x00748ACF>], 0
+  cmp       byte [<VERS 0x00741B59 0x00748B1B 0x00748ACF>], 0
   jnz       +0x06
   movzx     edx, byte [eax + esi * 4 + 0x04]  # main palette
   ret
@@ -81,7 +81,7 @@ patch_code_end2:
 patch_func_3:
   pop       ecx
   push      5
-  push      <VERS 0x007489ED 0x007489A1>
+  push      <VERS 0x007419C8 0x007489ED 0x007489A1>
   call      get_code_size3
   .deltaof  patch_code3, patch_code_end3
 get_code_size3:
@@ -89,7 +89,7 @@ get_code_size3:
   push      dword [eax]
   call      patch_code_end3
 patch_code3:
-  cmp       byte [<VERS 0x00748B1B 0x00748ACF>], 0
+  cmp       byte [<VERS 0x00741B59 0x00748B1B 0x00748ACF>], 0
   jnz       +0x06
   movzx     ecx, byte [eax + ecx * 2 + 0x05]  # main palette
   ret
@@ -103,7 +103,7 @@ patch_code_end3:
 patch_func_4:
   pop       ecx
   push      5
-  push      <VERS 0x00748A88 0x00748A3C>
+  push      <VERS 0x00741A63 0x00748A88 0x00748A3C>
   call      get_code_size4
   .deltaof  patch_code4, patch_code_end4
 get_code_size4:
@@ -111,7 +111,7 @@ get_code_size4:
   push      dword [eax]
   call      patch_code_end4
 patch_code4:
-  cmp       byte [<VERS 0x00748B1B 0x00748ACF>], 0
+  cmp       byte [<VERS 0x00741B59 0x00748B1B 0x00748ACF>], 0
   jnz       +0x06
   movzx     edx, byte [edx + ebx * 4 + 0x04]  # main palette
   ret
@@ -125,7 +125,7 @@ patch_code_end4:
 patch_func_5:
   pop       ecx
   push      5
-  push      <VERS 0x00748A97 0x00748A4B>
+  push      <VERS 0x00741A72 0x00748A97 0x00748A4B>
   call      get_code_size5
   .deltaof  patch_code5, patch_code_end5
 get_code_size5:
@@ -133,7 +133,7 @@ get_code_size5:
   push      dword [eax]
   call      patch_code_end5
 patch_code5:
-  cmp       byte [<VERS 0x00748B1B 0x00748ACF>], 0
+  cmp       byte [<VERS 0x00741B59 0x00748B1B 0x00748ACF>], 0
   jnz       +0x06
   movzx     ecx, byte [edx + eax * 2 + 0x05]  # main palette
   ret
@@ -147,7 +147,7 @@ patch_code_end5:
 patch_func_6:
   pop       ecx
   push      5
-  push      <VERS 0x007103D3 0x007103B7>
+  push      <VERS 0x0070A11F 0x007103D3 0x007103B7>
   call      get_code_size6
   .deltaof  patch_code6, patch_code_end6
 get_code_size6:
@@ -155,7 +155,7 @@ get_code_size6:
   push      dword [eax]
   call      patch_code_end6
 patch_code6:
-  cmp       byte [<VERS 0x00748B1B 0x00748ACF>], 0
+  cmp       byte [<VERS 0x00741B59 0x00748B1B 0x00748ACF>], 0
   jnz       +0x06
   movzx     ecx, byte [eax + edx * 4 + 0x04]  # main palette
   ret
@@ -169,7 +169,7 @@ patch_code_end6:
 patch_func_7:
   pop       ecx
   push      5
-  push      <VERS 0x007103DC 0x007103C0>
+  push      <VERS 0x0070A128 0x007103DC 0x007103C0>
   call      get_code_size7
   .deltaof  patch_code7, patch_code_end7
 get_code_size7:
@@ -177,7 +177,7 @@ get_code_size7:
   push      dword [eax]
   call      patch_code_end7
 patch_code7:
-  cmp       byte [<VERS 0x00748B1B 0x00748ACF>], 0
+  cmp       byte [<VERS 0x00741B59 0x00748B1B 0x00748ACF>], 0
   jnz       +0x06
   movzx     ecx, byte [eax + edx * 4 + 0x05]  # main palette
   ret
@@ -190,29 +190,29 @@ patch_code_end7:
 write_code_blocks:
   .include  WriteCodeBlocks
 
-  .data     <VERS 0x00748A05 0x007489B9>
+  .data     <VERS 0x007419E0 0x00748A05 0x007489B9>
   .deltaof  code_block1_start, code_block1_end
 
 # UnsetHotkey1
 code_block1_start:
-  push      dword [<VERS 0x00748B1B 0x00748ACF>]
+  push      dword [<VERS 0x00741B59 0x00748B1B 0x00748ACF>]
   push      eax
-  mov       eax, <VERS 0x0068CE4C 0x0068CDE0>                   # SetPaletteHotkey
+  mov       eax, <VERS 0x00687710 0x0068CE4C 0x0068CDE0>                   # SetPaletteHotkey
   call      eax
   .binary   909090909090909090
 code_block1_end:
-  .data     <VERS 0x00748AAB 0x00748A5F>
+  .data     <VERS 0x00741A86 0x00748AAB 0x00748A5F>
   .deltaof  code_block2_start, code_block2_end
 
 # UnsetHotkey2
 code_block2_start:
-  push      dword [<VERS 0x00748B1B 0x00748ACF>]
+  push      dword [<VERS 0x00741B59 0x00748B1B 0x00748ACF>]
   push      eax
-  mov       eax, <VERS 0x0068CE4C 0x0068CDE0>                   # SetPaletteHotkey
+  mov       eax, <VERS 0x00687710 0x0068CE4C 0x0068CDE0>                   # SetPaletteHotkey
   call      eax
   .binary   909090909090909090
 code_block2_end:
-  .data     <VERS 0x00748B0A 0x00748ABE>
+  .data     <VERS 0x00741B48 0x00748B0A 0x00748ABE>
   .deltaof  code_block3_start, code_block3_end
 
 # SetHotkey
@@ -224,9 +224,9 @@ code_block3_start:
   push      edx
   push      ebx
   push      esi
-  .binary   6800000000                        # tmpCurrentPalette = <VERS 0x00748B1B 0x00748ACF>
+  .binary   6800000000                        # tmpCurrentPalette = <VERS 0x00741B59 0x00748B1B 0x00748ACF>
   push      0
-  mov       eax, <VERS 0x0068CE4C 0x0068CDE0>                   # SetPaletteHotkey
+  mov       eax, <VERS 0x00687710 0x0068CE4C 0x0068CDE0>                   # SetPaletteHotkey
   call      eax
   .binary   90909090909090909090909090909090
 code_block3_end:

--- a/system/client-functions/System/GetEnemyEntity.inc.s
+++ b/system/client-functions/System/GetEnemyEntity.inc.s
@@ -1,7 +1,7 @@
 # (uint16_t entity_id @ eax) -> TObjectV00b441c0* @ eax
 # Preserves all registers except eax
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 get_enemy_entity:
   push      esi
@@ -15,15 +15,15 @@ get_enemy_entity:
   cmp       edx, 0x4000
   jge       done
 
-  mov       esi, [<VERS 0x00AABCE8 0x00AAE168>]  # bs_low = next_player_entity_index
-  mov       edi, [<VERS 0x00AABCE4 0x00AAE164>]
+  mov       esi, [<VERS 0x00AA1CA8 0x00AABCE8 0x00AAE168>]  # bs_low = next_player_entity_index
+  mov       edi, [<VERS 0x00AA1CA4 0x00AABCE4 0x00AAE164>]
   lea       edi, [edi + esi - 1]  # bs_high = next_player_entity_index + next_enemy_entity_index - 1
 bs_again:
   cmp       esi, edi
   jge       bs_done
   lea       ecx, [esi + edi]
   shr       ecx, 1
-  mov       eax, [ecx * 4 + <VERS 0x00AAB2A0 0x00AAD720>]  # all_entities[ecx]
+  mov       eax, [ecx * 4 + <VERS 0x00AA1260 0x00AAB2A0 0x00AAD720>]  # all_entities[ecx]
   cmp       [eax + 0x1C], dx
   jge       bs_not_less
   lea       esi, [ecx + 1]
@@ -33,7 +33,7 @@ bs_not_less:
   jmp       bs_again
 bs_done:
 
-  mov       eax, [esi * 4 + <VERS 0x00AAB2A0 0x00AAD720>]  # all_entities[bs_low]
+  mov       eax, [esi * 4 + <VERS 0x00AA1260 0x00AAB2A0 0x00AAD720>]  # all_entities[bs_low]
   test      eax, eax
   je        done
   xor       ecx, ecx

--- a/system/client-functions/System/WriteAddressOfCode.inc.s
+++ b/system/client-functions/System/WriteAddressOfCode.inc.s
@@ -7,7 +7,7 @@
 # allocated code at the specified pointer. The allocated memory is never freed. This function pops its arguments off
 # the stack before returning.
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 write_call_to_code:
   # [esp + 0x04] = code ptr
@@ -15,9 +15,9 @@ write_call_to_code:
   # [esp + 0x0C] = ptr addr
 
   # Allocate memory for the copied code
-  mov       ecx, [<VERS 0x00AA8F84 0x00AAB404>]
+  mov       ecx, [<VERS 0x00A9EF44 0x00AA8F84 0x00AAB404>]
   push      dword [esp + 0x08]
-  mov       eax, <VERS 0x007A984C 0x007A8A38>
+  mov       eax, <VERS 0x007A2254 0x007A984C 0x007A8A38>
   call      eax  # malloc7
   test      eax, eax
   je        done

--- a/system/client-functions/System/WriteCallToCode.inc.s
+++ b/system/client-functions/System/WriteCallToCode.inc.s
@@ -1,4 +1,4 @@
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 # This file defines the following function:
 #   write_call_to_code(
@@ -20,9 +20,9 @@ write_call_to_code:
   # [esp + 0x10] = callsite size (if zero, write the address instead of a call)
 
   # Allocate memory for the copied code
-  mov       ecx, [<VERS 0x00AA8F84 0x00AAB404>]
+  mov       ecx, [<VERS 0x00A9EF44 0x00AA8F84 0x00AAB404>]
   push      dword [esp + 0x08]
-  mov       eax, <VERS 0x007A984C 0x007A8A38>
+  mov       eax, <VERS 0x007A2254 0x007A984C 0x007A8A38>
   call      eax  # malloc7
   test      eax, eax
   je        done

--- a/system/client-functions/System/WriteCallToCodeMulti.inc.s
+++ b/system/client-functions/System/WriteCallToCodeMulti.inc.s
@@ -14,7 +14,7 @@
 
 
 
-.versions 59NJ 59NL
+.versions 50YJ 59NJ 59NL
 
 write_call_to_code:
   # [esp + 0x04] = code ptr
@@ -25,9 +25,9 @@ write_call_to_code:
   # ... (further callsite address/size pairs)
 
   # Allocate memory for the copied code
-  mov       ecx, [<VERS 0x00AA8F84 0x00AAB404>]
+  mov       ecx, [<VERS 0x00A9EF44 0x00AA8F84 0x00AAB404>]
   push      dword [esp + 0x08]
-  mov       eax, <VERS 0x007A984C 0x007A8A38>
+  mov       eax, <VERS 0x007A2254 0x007A984C 0x007A8A38>
   call      eax  # malloc7
   test      eax, eax
   je        done

--- a/system/client-functions/System/WriteCodeBlocks.inc.s
+++ b/system/client-functions/System/WriteCodeBlocks.inc.s
@@ -118,7 +118,7 @@ first_patch_header:
 
 
 
-.versions 2OJW 2OJZ 59NJ 59NL
+.versions 2OJW 2OJZ 50YJ 59NJ 59NL
 
 start:
   push    ebx


### PR DESCRIPTION
Tested to the best of my abilities.
As usual, DMC patch is largely untested. However, it at least does not cause any crashes.

Things to note: 
"sig_check_begin" in MoreSaveSlots.s is structured a bit differently in this client than in 59NL/59NJ (Mainly swapping ecx and edx registers). I couldn't get this function to trigger in game, even with a breakpoint set. So I was unable to test if it works correctly. Otherwise, the patch seems to work flawlessly.

I included notes on getting this client up and running in a separate commit to the patches. I don't know if GitHub lets you cherrypick which commits get pulled. If so, feel free to not include them if you don't want them.

I now see offsets when I close my eyes.