### PR TITLE
Fix ClearUnreleasedItemList.s for 50YJ

### DIFF
--- a/system/client-functions/BlueBurstExclusive/ClearUnreleasedItemList.s
+++ b/system/client-functions/BlueBurstExclusive/ClearUnreleasedItemList.s
@@ -15,7 +15,7 @@ reloc0:
 start:
   xor       eax, eax
   mov       edx, esp
-  mov       esp, <VERS 0x009EC359 0x009F61B0 0x009F81B0>
+  mov       esp, <VERS 0x009EC35B 0x009F61B0 0x009F81B0>
   mov       ecx, 0x3C
 again:
   push      0


### PR DESCRIPTION
Somehow this crashes the game with every character class except RAcaseal, which happened to be the character I was using for testing, where it worked perfectly.
Funny how that works.