### PR TITLE
Change to config.example.json to reflect correct Bank parameters

### DIFF
--- a/system/config.example.json
+++ b/system/config.example.json
@@ -586,8 +586,8 @@
 
   // BB bank size. If you change either of these values, you must also add "BankSize" to BBRequiredPatches, and change
   // the patch contents in system/client-functions/BlueBurstExclusive/BankSize.5___.patch.s to reflect the counts here.
-  "BBMaxBankItems": 200,
-  "BBMaxBankMeseta": 999999,
+  "BBBankItemLimit": 200,
+  "BBBankMesetaLimit": 999999,
 
   // Item stack limits. Note that changing these does not affect the client's behavior automatically - this only exists
   // to allow the server to understand the behavior of clients that are already patched with different stack limits.


### PR DESCRIPTION
Really small change, set up a server today and enabled some patches, and client broke.

Using `BBMaxBankItems` and `BBMaxBankMeseta` like in the config will cause the client to stop when creating a room if `BankSize` is added to `BBRequiredPatches` 

Comments in `BankSize.s` says it should be `BBBankItemLimit` and `BBBankMesetaLimit` instead.

Changing my config to use "Limit" vs "Max" fixed the issue. 

This just updates the `config.example.json` to use the right names